### PR TITLE
Move RSTUF to github.com/repository-service-tuf

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: I need help
-    url: https://github.com/vmware/repository-service-tuf
+    url: https://github.com/repository-service-tuf/repository-service-tuf
     about: If you have questions or need help

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -124,7 +124,7 @@ jobs:
            ref: main
 
       - name: Deploy online.key to Docker Volume
-        # This is an workaround for the issue https://github.com/vmware/repository-service-tuf-worker/issues/241
+        # This is an workaround for the issue https://github.com/repository-service-tuf/repository-service-tuf-worker/issues/241
         # Once solving it:
         # 1. Change workers to use secrets with the online key
         # 2. Remove this step

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "repository-service-tuf-worker"]
 	path = repository-service-tuf-worker
-	url = https://github.com/vmware/repository-service-tuf-worker.git
+	url = https://github.com/repository-service-tuf/repository-service-tuf-worker.git
 [submodule "repository-service-tuf-api"]
 	path = repository-service-tuf-api
-	url = https://github.com/vmware/repository-service-tuf-api.git
+	url = https://github.com/repository-service-tuf/repository-service-tuf-api.git
 [submodule "repository-service-tuf-cli"]
 	path = repository-service-tuf-cli
-	url = https://github.com/vmware/repository-service-tuf-cli.git
+	url = https://github.com/repository-service-tuf/repository-service-tuf-cli.git

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -43,10 +43,10 @@ contribute.
 Check the specific repository CONTRIBUTING documentation for more specific
 details:
 
-* `Umbrella Repository Service for TUF <https://github.com/vmware/repository-service-tuf/blob/main/CONTRIBUTING.rst>`_
-* `Repository Service for TUF API <https://github.com/vmware/repository-service-tuf-api/blob/main/CONTRIBUTING.rst>`_
-* `Repository Service for TUF Worker <https://github.com/vmware/repository-service-tuf-worker/blob/main/CONTRIBUTING.rst>`_
-* `Repository Service for TUF Command Line Interface (CLI) <https://github.com/vmware/repository-service-tuf-cli/blob/main/CONTRIBUTING.rst>`_
+* `Umbrella Repository Service for TUF <https://github.com/repository-service-tuf/repository-service-tuf/blob/main/CONTRIBUTING.rst>`_
+* `Repository Service for TUF API <https://github.com/repository-service-tuf/repository-service-tuf-api/blob/main/CONTRIBUTING.rst>`_
+* `Repository Service for TUF Worker <https://github.com/repository-service-tuf/repository-service-tuf-worker/blob/main/CONTRIBUTING.rst>`_
+* `Repository Service for TUF Command Line Interface (CLI) <https://github.com/repository-service-tuf/repository-service-tuf-cli/blob/main/CONTRIBUTING.rst>`_
 
 .. rstuf-contributing-links
 
@@ -56,7 +56,7 @@ Getting the source code
 =======================
 
 `Fork <https://docs.github.com/en/get-started/quickstart/fork-a-repo>`_ the
-repository on `GitHub <https://github.com/vmware/repository-service-tuf>`_ and
+repository on `GitHub <https://github.com/repository-service-tuf/repository-service-tuf>`_ and
 `clone <https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository>`_
 it to your local machine:
 
@@ -73,7 +73,7 @@ you stay up-to-date with our repository:
 
 .. code-block:: console
 
-    git remote add upstream https://github.com/vmware/repository-service-tuf
+    git remote add upstream https://github.com/repository-service-tuf/repository-service-tuf
     git checkout main
     git fetch upstream
     git merge upstream/main

--- a/ROADMAP.rst
+++ b/ROADMAP.rst
@@ -21,13 +21,13 @@ Features:
 - [x] Automatically version Bump Snapshot Metadata
 - [x] Automatically version Bump Timestamp Metadata
 - [x] Automatically version Bump hash-bins Metadata
-- [x] Release CI/CD in all components (`Issue #25 <https://github.com/vmware/repository-service-tuf/issues/25>`_)
+- [x] Release CI/CD in all components (`Issue #25 <https://github.com/repository-service-tuf/repository-service-tuf/issues/25>`_)
 
 Components Milestones:
 
-- `repository-service-tuf-api v0.0.1aX <https://github.com/vmware/repository-service-tuf-api/milestone/2>`_
-- `repository-service-tuf-worker v0.0.1aX <https://github.com/vmware/repository-service-tuf-worker/milestone/2>`_
-- `repository-service-tuf-cli v0.0.1aX <https://github.com/vmware/repository-service-tuf-cli/milestone/2>`_
+- `repository-service-tuf-api v0.0.1aX <https://github.com/repository-service-tuf/repository-service-tuf-api/milestone/2>`_
+- `repository-service-tuf-worker v0.0.1aX <https://github.com/repository-service-tuf/repository-service-tuf-worker/milestone/2>`_
+- `repository-service-tuf-cli v0.0.1aX <https://github.com/repository-service-tuf/repository-service-tuf-cli/milestone/2>`_
 
 
 Goal: Minimum Working Version
@@ -39,22 +39,22 @@ Not for a Production Deploy.
 This release is to evaluate the features and functionality.
 
 
-- [x] Public online documentation (`Issue #22 <https://github.com/vmware/repository-service-tuf/issues/22>`_)
-- [x] Implement HTTPS for the Rest API (`Issue #6 <https://github.com/vmware/repository-service-tuf/issues/6>`_)
-- [x] Data load for migrations (`Issue #188 <https://github.com/vmware/repository-service-tuf/issues/188>`_)
-- [x] Remove the BIN Keys from Ceremony/Bootstrap Process [Roles simplification] (`Issue #28 <https://github.com/vmware/repository-service-tuf/issues/28>`_)
-- [x] Remove from the bootstrap the online keys [Roles simplification] (`Issue #207 <https://github.com/vmware/repository-service-tuf/issues/207>`_)
-- [x] Simplify the metadata bootstrap process [Roles simplification] (`Issue #208 <https://github.com/vmware/repository-service-tuf/issues/208>`_)
-- [ ] Key(s) Rotation (`Issue #23 <https://github.com/vmware/repository-service-tuf/issues/23>`_)
-- [ ] Option to Disable the API Authentication/Authorization (`Issue #41 <https://github.com/vmware/repository-service-tuf/issues/41>`_)
+- [x] Public online documentation (`Issue #22 <https://github.com/repository-service-tuf/repository-service-tuf/issues/22>`_)
+- [x] Implement HTTPS for the Rest API (`Issue #6 <https://github.com/repository-service-tuf/repository-service-tuf/issues/6>`_)
+- [x] Data load for migrations (`Issue #188 <https://github.com/repository-service-tuf/repository-service-tuf/issues/188>`_)
+- [x] Remove the BIN Keys from Ceremony/Bootstrap Process [Roles simplification] (`Issue #28 <https://github.com/repository-service-tuf/repository-service-tuf/issues/28>`_)
+- [x] Remove from the bootstrap the online keys [Roles simplification] (`Issue #207 <https://github.com/repository-service-tuf/repository-service-tuf/issues/207>`_)
+- [x] Simplify the metadata bootstrap process [Roles simplification] (`Issue #208 <https://github.com/repository-service-tuf/repository-service-tuf/issues/208>`_)
+- [ ] Key(s) Rotation (`Issue #23 <https://github.com/repository-service-tuf/repository-service-tuf/issues/23>`_)
+- [ ] Option to Disable the API Authentication/Authorization (`Issue #41 <https://github.com/repository-service-tuf/repository-service-tuf/issues/41>`_)
 
 `Minimum Working Version (MWV) Board <https://github.com/orgs/vmware/projects/13/views/1>`_.
 
 Components Milestones:
 
-- `repository-service-tuf-api v1.0.0bX <https://github.com/vmware/repository-service-tuf-api/milestone/3>`_
-- `repository-service-tuf-worker v1.0.0bX <https://github.com/vmware/repository-service-tuf-worker/milestone/3>`_
-- `repository-service-tuf-cli v1.0.0bX <https://github.com/vmware/repository-service-tuf-cli/milestone/3>`_
+- `repository-service-tuf-api v1.0.0bX <https://github.com/repository-service-tuf/repository-service-tuf-api/milestone/3>`_
+- `repository-service-tuf-worker v1.0.0bX <https://github.com/repository-service-tuf/repository-service-tuf-worker/milestone/3>`_
+- `repository-service-tuf-cli v1.0.0bX <https://github.com/repository-service-tuf/repository-service-tuf-cli/milestone/3>`_
 
 
 Goal: Minimum Valuable Product
@@ -65,16 +65,16 @@ Status: TBD
 First Production Deploy
 This release achive the minimum valuable product for users.
 
-- [ ] Old Metadata retention (`Issue #29 <https://github.com/vmware/repository-service-tuf/issues/29>`_)
-- [ ] Deployment Design Document (`Issue #227 <https://github.com/vmware/repository-service-tuf/issues/227>`_)
-- [ ] Support to AWS S3 (Storage) and AWS KMS (Key Vault) (`Issue #24 <https://github.com/vmware/repository-service-tuf/issues/24>`_)
-- [ ] Token revocation (`Issue #30 <https://github.com/vmware/repository-service-tuf/issues/30>`_)
+- [ ] Old Metadata retention (`Issue #29 <https://github.com/repository-service-tuf/repository-service-tuf/issues/29>`_)
+- [ ] Deployment Design Document (`Issue #227 <https://github.com/repository-service-tuf/repository-service-tuf/issues/227>`_)
+- [ ] Support to AWS S3 (Storage) and AWS KMS (Key Vault) (`Issue #24 <https://github.com/repository-service-tuf/repository-service-tuf/issues/24>`_)
+- [ ] Token revocation (`Issue #30 <https://github.com/repository-service-tuf/repository-service-tuf/issues/30>`_)
 
 Components Milestones:
 
-- `repository-service-tuf-api v1.0.X <https://github.com/vmware/repository-service-tuf-api/milestone/4>`_
-- `repository-service-tuf-worker v1.0.X <https://github.com/vmware/repository-service-tuf-worker/milestone/4>`_
-- `repository-service-tuf-cli v1.0.X <https://github.com/vmware/repository-service-tuf-cli/milestone/4>`_
+- `repository-service-tuf-api v1.0.X <https://github.com/repository-service-tuf/repository-service-tuf-api/milestone/4>`_
+- `repository-service-tuf-worker v1.0.X <https://github.com/repository-service-tuf/repository-service-tuf-worker/milestone/4>`_
+- `repository-service-tuf-cli v1.0.X <https://github.com/repository-service-tuf/repository-service-tuf-cli/milestone/4>`_
 
 
 Goal: End-to-End Signing

--- a/docs/source/devel/development.rst
+++ b/docs/source/devel/development.rst
@@ -5,7 +5,7 @@ Development process
 
 
 This document, specifically the `file ROADMAP.rst
-<https://github.com/vmware/repository-service-tuf/blob/main/ROADMAP.rst>`_, defines the
+<https://github.com/repository-service-tuf/repository-service-tuf/blob/main/ROADMAP.rst>`_, defines the
 :ref:`Repository Service for TUF Roadmap <devel/release:Roadmap>`.
 
 Each Roadmap Goal must have a `project in the Repository Service for TUF Organization
@@ -13,12 +13,12 @@ Each Roadmap Goal must have a `project in the Repository Service for TUF Organiz
 
 The :ref:`devel/release:Roadmap` contains the desired Repository Service for
 TUF (RSTUF) features. Each feature has an issue open in the
-`vmware/repository-service-tuf <https://github.com/vmware/repository-service-tuf>`_
+`vmware/repository-service-tuf <https://github.com/repository-service-tuf/repository-service-tuf>`_
 (Umbrella repository) issues.
 
 The Component specifies the Milestone (release) that will contain the Roadmap
 Goal in the `ROADMAP.rst
-<https://github.com/vmware/repository-service-tuf/blob/main/ROADMAP.rst>`_ (:ref:`also
+<https://github.com/repository-service-tuf/repository-service-tuf/blob/main/ROADMAP.rst>`_ (:ref:`also
 visible below <devel/release:Roadmap>`).
 
 It allows the Component Maintainers to combine Repository Service for TUF Features and internal
@@ -157,7 +157,7 @@ cross-components or even user usage change.
 We recommend for these changes the following:
 
 * Always design/document the feature in a `new issue
-  <https://github.com/vmware/repository-service-tuf/issues/new?assignees=&labels=feature&template=feature.yml&title=Feature%3A+>`_.
+  <https://github.com/repository-service-tuf/repository-service-tuf/issues/new?assignees=&labels=feature&template=feature.yml&title=Feature%3A+>`_.
 
   - Use as many diagrams as possible (PlantUML or Mermaid in the issues). ❤️
 
@@ -197,7 +197,7 @@ BDD Feature file
 For RSTUF Features level, we write the `Gherkin
 <https://cucumber.io/docs/gherkin/reference/>`_ feature file in the
 `test features
-<https://github.com/vmware/repository-service-tuf/tree/main/tests/features>`_.
+<https://github.com/repository-service-tuf/repository-service-tuf/tree/main/tests/features>`_.
 
 The goal is to describe the Scenarios and Behavior for our feature clearly.
 We try to have clear requirements for implementing, maintaining, and changing
@@ -217,10 +217,10 @@ We use `pytest <https://docs.pytest.org/>`_ and
 `pytest-bdd <https://pytest-bdd.readthedocs.io/en/stable/>`_ as the framework.
 
 All BDD tests are in the `Umbrella repository, inside
-tests/functional <http://github.com/vmware/repository-service-tuf>`_ .
+tests/functional <http://github.com/repository-service-tuf/repository-service-tuf>`_ .
 
 The BDD tests have the workflow also in the `Umbrella repository
-<http://github.com/vmware/repository-service-tuf>`_ , as a reusable
+<http://github.com/repository-service-tuf/repository-service-tuf>`_ , as a reusable
 GitHub Workflow, and it is triggered by other workflows/components i.e.,
 before releasing.
 
@@ -234,8 +234,8 @@ Each RSTUF components have its own development instructions.
 Components Repositories
 -----------------------
 
-    - `Repository Service for TUF REST API <https://github.com/vmware/repository-service-tuf-api>`_ (``repository-service-tuf-api``)
-    - `Repository Service for TUF Worker <https://github.com/vmware/repository-service-tuf-rworker>`_ (``repository-service-tuf-worker``)
-    - `Repository Service for TUF Command Line Interface <https://github.com/vmware/repository-service-tuf-cli>`_ (``repository-service-tuf-cli``)
+    - `Repository Service for TUF REST API <https://github.com/repository-service-tuf/repository-service-tuf-api>`_ (``repository-service-tuf-api``)
+    - `Repository Service for TUF Worker <https://github.com/repository-service-tuf/repository-service-tuf-rworker>`_ (``repository-service-tuf-worker``)
+    - `Repository Service for TUF Command Line Interface <https://github.com/repository-service-tuf/repository-service-tuf-cli>`_ (``repository-service-tuf-cli``)
 
 


### PR DESCRIPTION
It is part of the process moving RSTUF to OpenSSF organization.