### PR TITLE
Force RSTUF to use built-in auth on FT

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -103,6 +103,7 @@ jobs:
           RSTUF_BOOTSTRAP_NODE: "true"
           RSTUF_BROKER_SERVER: amqp://guest:guest@rabbitmq:5672
           RSTUF_REDIS_SERVER: redis://redis
+          RSTUF_AUTH: "true"
           SECRETS_RSTUF_TOKEN_KEY: test-token-key
           SECRETS_RSTUF_ADMIN_PASSWORD: secret
     steps:


### PR DESCRIPTION
This commit just enforces or make explicit that RSTUF deployment for FT test uses the built-in authentication/authorization.