### PR TITLE
FT workflow_call requires secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,5 @@ jobs:
       api_version: dev
       worker_version: dev
       cli_version: dev
+    secrets:
+      RSTUF_ONLINE_KEY: ${{ secrets.RSTUF_ONLINE_KEY }}

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -35,6 +35,9 @@ on:
         default: "latest"
         type: string
         required: False
+    secrets:
+      RSTUF_ONLINE_KEY:
+        required: True
 env:
   MAKE_FT_TARGET: functional-tests
   REQUIREMENTS_PATH: requirements.txt

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -10,6 +10,8 @@ jobs:
       api_version: dev
       worker_version: dev
       cli_version: dev
+    secrets:
+      RSTUF_ONLINE_KEY: ${{ secrets.RSTUF_ONLINE_KEY }}
   sync-submodules:
     name: "Sync submodules and RSTUF docs"
     runs-on: ubuntu-latest


### PR DESCRIPTION
In order for other workflows call the `functional.yml` workflow it is required to receive the secrets for the `RSTUF_ONLINE_KEY`.

- Updated the `.github/workflows/ci.yml`
- Updated the `.github/workflows/update-submodules.yml`