### PR TITLE
Update ROADMAP.rst feature finished: disable auth

### DIFF
--- a/ROADMAP.rst
+++ b/ROADMAP.rst
@@ -45,8 +45,8 @@ This release is to evaluate the features and functionality.
 - [x] Remove the BIN Keys from Ceremony/Bootstrap Process [Roles simplification] (`Issue #28 <https://github.com/repository-service-tuf/repository-service-tuf/issues/28>`_)
 - [x] Remove from the bootstrap the online keys [Roles simplification] (`Issue #207 <https://github.com/repository-service-tuf/repository-service-tuf/issues/207>`_)
 - [x] Simplify the metadata bootstrap process [Roles simplification] (`Issue #208 <https://github.com/repository-service-tuf/repository-service-tuf/issues/208>`_)
+- [x] Option to Disable the API Authentication/Authorization (`Issue #41 <https://github.com/repository-service-tuf/repository-service-tuf/issues/41>`_)
 - [ ] Key(s) Rotation (`Issue #23 <https://github.com/repository-service-tuf/repository-service-tuf/issues/23>`_)
-- [ ] Option to Disable the API Authentication/Authorization (`Issue #41 <https://github.com/repository-service-tuf/repository-service-tuf/issues/41>`_)
 
 `Minimum Working Version (MWV) Board <https://github.com/orgs/repository-service-tuf/projects/2>`_.
 


### PR DESCRIPTION
Update RSTUF roadmap closing the feature: Option to Disable the API Authentication/Authorization.

The feature was closed by issue #282 which implemented a mechanism to enable/disable the Auth.

Issue #41 was renamed to: Refactoring Authentication/Authorization as an API service. It contains multiple tasks, including #282 which was closed.