### PR TITLE
Functional tests uses `RSTUF CLI` with `--auth`

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -189,7 +189,7 @@ jobs:
           pip install rstuf-cli/
 
       - name: Login to RSTUF service
-        run: rstuf -c rstuf.ini admin login -s http://localhost -u admin -p secret -e 1
+        run: rstuf --auth -c rstuf.ini admin login -s http://localhost -u admin -p secret -e 1
 
       - name: Run the Offline Ceremony using RSTUF saving payload.json
         # Notes:
@@ -204,7 +204,7 @@ jobs:
 
       - name: Run RSTUF Ceremony Bootstrap Upload
         timeout-minutes: 2
-        run: 'rstuf -c rstuf.ini admin ceremony -b -u -f payload.json'
+        run: 'rstuf --auth -c rstuf.ini admin ceremony -b -u -f payload.json --upload-server http://localhost'
 
       - name: Functional Tests (BDD)
         env:

--- a/tests/functional/bootstrap/test_bootstrap.py
+++ b/tests/functional/bootstrap/test_bootstrap.py
@@ -35,7 +35,9 @@ def the_admin_is_logged(login):
 
 @when("the admin run rstuf for ceremony bootstrap", target_fixture="bootstrap")
 def the_administrator_uses_rstufcli_bootstrap(rstuf_cli):
-    rc, output = rstuf_cli("admin ceremony -b -u -f payload.json")
+    rc, output = rstuf_cli(
+        "admin ceremony -b -u -f payload.json --upload-server http://localhost"
+    )
     return rc, output
 
 
@@ -67,7 +69,7 @@ def test_bootstrap_using_rstuf_cli_with_invalid_payload():
 )
 def the_administrator_uses_rstufcli_bootstrap_invalid_payload(rstuf_cli):
     rc, output = rstuf_cli(
-        "admin ceremony -b -u -f tests/data/payload-invalid.json"
+        "admin ceremony -b -u -f tests/data/payload-invalid.json --upload-server http://localhost"
     )
 
     return rc, output

--- a/tests/functional/bootstrap/test_bootstrap.py
+++ b/tests/functional/bootstrap/test_bootstrap.py
@@ -69,7 +69,8 @@ def test_bootstrap_using_rstuf_cli_with_invalid_payload():
 )
 def the_administrator_uses_rstufcli_bootstrap_invalid_payload(rstuf_cli):
     rc, output = rstuf_cli(
-        "admin ceremony -b -u -f tests/data/payload-invalid.json --upload-server http://localhost"
+        "admin ceremony -b -u -f tests/data/payload-invalid.json "
+        "--upload-server http://localhost"
     )
 
     return rc, output

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -22,7 +22,8 @@ def rstuf_cli():
     def _run_rstuf_cli(params: List):
         ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
         result = subprocess.run(
-            ["rstuf", "-c", "rstuf.ini"] + params.split(), capture_output=True
+            ["rstuf", "--auth", "-c", "rstuf.ini"] + params.split(),
+            capture_output=True,
         )
 
         return result.returncode, ansi_escape.sub(


### PR DESCRIPTION
As implemented by CLI
(https://github.com/repository-service-tuf/repository-service-tuf-cli/pull/289) the functional tests require to use the `--auth` parameters to be compatible with the existent tests, these tests use a API running the built-in authentication.

Note: We are planning changing the FT to be compatible with issue #41 This commit doesn't aim this change. It fix the current state.