### PR TITLE
Fix the RSTUF logo in the RTD

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,7 +68,7 @@ html_theme = 'sphinx_rtd_theme'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
-html_logo = '_static/rstuf-logo.png'
+html_logo = '_static/logo/PNG/rstuf_horizontal-color.png'
 html_favicon = '_static/rstuf.ico'
 # HTML Theme Options
 html_theme_options = {


### PR DESCRIPTION
Fix the RSTUF logo for repository-service-tuf.readthedocs.io