### PR TITLE
Introduce the Community Meetings

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,6 +8,11 @@ taking the time to contribute!
 Please familiarize yourself with the `Code of Conduct`_
 before contributing.
 
+Meetings
+========
+
+* `Community Meetings <https://hackmd.io/sSB1pwpDR5Seag0YB-vYMA>`_
+
 DCO
 ===
 


### PR DESCRIPTION
Add information for Community Meetings in the `CONTRIBUTING.rst` (which also includes to the Read The Docs).

The information about meetings will be updated on HackMD.