### PR TITLE
Introducing RSTUF-TAC

### DIFF
--- a/TAC.rst
+++ b/TAC.rst
@@ -3,7 +3,7 @@ Technical Advisory Council (RSTUF-TAC)
 ######################################
 
 The role of the Technical Advisory Council (TAC) is to provide subject matter
-expertise on software repository design, to make recommendations and guide the
+expertise in software repository design, to make recommendations and guide the
 future activities of the technical community.
 
 Get Involved
@@ -32,7 +32,7 @@ Voting Member
 
 .. note::
     Functional features, such as support, stability, securing, strength,
-    behavior, etc., have high-priority on user/repository features.
+    behavior, etc., have higher priority over user/repository features.
 
 RSTUF-TAC Members
 #################

--- a/TAC.rst
+++ b/TAC.rst
@@ -31,7 +31,8 @@ Voting Member
   has one vote)
 
 .. note::
-    Functional features, such as support, stability, securing, strength,
+
+  * Functional features, such as support, stability, securing, strength,
     behavior, etc., have higher priority over user/repository features.
 
 RSTUF-TAC Members
@@ -45,14 +46,16 @@ RSTUF-TAC Members
       - Role
       - Organization
       - Github
-    * - Kairo de Araujo
+    * - | Kairo de Araujo
+        | Martin Vrachev
+        | Konstantinos Papadopoulos
+        | Lukas Pühringer
       - Voting Member
       - RSTUF Maintainer
-      - @kairoaraujo
-    * - Martin Vrachev
-      - Voting Member
-      - RSTUF Maintainer
-      - @MVrachev
+      - | @kairoaraujo
+        | @MVrachev
+        | @KAUTH
+        | @lukpueh
     * - `<name>`
       - Voting Member
       - The Update Framework Maintainer
@@ -66,3 +69,9 @@ RSTUF-TAC Members
       - <Public Repository Name>
       - `@github account`
 
+.. note::
+
+  * Organizations could have more than 1 member, but they have the right to 1
+    vote. It's recommended that organizations have more than one person listed
+    in the TAC list to allow substitutions in the absence of a listed member.
+  * A TAC member part of multiple organizations can vote for only one.

--- a/TAC.rst
+++ b/TAC.rst
@@ -1,0 +1,68 @@
+######################################
+Technical Advisory Council (RSTUF-TAC)
+######################################
+
+The role of the Technical Advisory Council (TAC) is to provide subject matter
+expertise on software repository design, to make recommendations and guide the
+future activities of the technical community.
+
+Get Involved
+############
+
+If you are maintaining a public repository and would like to join the
+discussion, just open a PR adding your details in the TAC Members table.
+TAC members will review it at the next meeting.
+
+Meetings
+########
+
+The TAC members meet (and vote if there is a quorum) on-demand as part of the
+`RSTUF Community Meeting <https://repository-service-tuf.readthedocs.io/en/stable/devel/contributing.html#meetings>`_.
+
+TAC Roles and Responsibilities
+##############################
+
+Voting Member
+=============
+
+* Shares use cases
+* Provides subject matter expertise on software repository design
+* Votes on user/repository features priority in the roadmap (each organization
+  has one vote)
+
+.. note::
+    Functional features, such as support, stability, securing, strength,
+    behavior, etc., have high-priority on user/repository features.
+
+RSTUF-TAC Members
+#################
+
+.. list-table:: RSTUF-TAC Members
+    :header-rows: 1
+    :widths: 20 20 40 20
+
+    * - Representative
+      - Role
+      - Organization
+      - Github
+    * - Kairo de Araujo
+      - Voting Member
+      - RSTUF Maintainer
+      - @kairoaraujo
+    * - Martin Vrachev
+      - Voting Member
+      - RSTUF Maintainer
+      - @MVrachev
+    * - `<name>`
+      - Voting Member
+      - The Update Framework Maintainer
+      - `@github account`
+    * - `<name>`
+      - Voting Member
+      - OpenSSF/Securing Software Repo WG
+      - `@github account`
+    * - `<name>`
+      - Voting Member
+      - <Public Repository Name>
+      - `@github account`
+

--- a/docs/source/devel/index.rst
+++ b/docs/source/devel/index.rst
@@ -6,6 +6,7 @@ Development Guide
    :maxdepth: 2
 
    contributing
+   tac
    development
    release
    documentation

--- a/docs/source/devel/tac.rst
+++ b/docs/source/devel/tac.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../TAC.rst


### PR DESCRIPTION
Empowering the participation from TUF, OpenSSF, and public repository maintainers. This initiative aims to give them a stronger voice in shaping the direction of the RSTUF project. The ultimate goal is to establish RSTUF as a neutral project with widespread benefits.