### PR TITLE
Fix repository setting name mistake

### DIFF
--- a/docs/source/devel/design.rst
+++ b/docs/source/devel/design.rst
@@ -118,13 +118,13 @@ operations.
         * - ``NUMBER_OF_DELEGATED_BINS``
           - | ``int``
           - Number of delegated hash bin roles
-        * - ``SIGNING_<ROLE NAME>``
+        * - ``<ROLE NAME>_SIGNING``
           - | ``None``
             | ``<json>``
           - | ``None``: No pending signature(s)
             | ``json``: TUF Metadata pending signature
             | It uses the role name uppercase
-            | Example ``SIGNING_ROOT``
+            | Example ``ROOT_SIGNING``
 
 Target Files and Target Roles
 =============================


### PR DESCRIPTION
Fix repository setting name mistake

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>