### PR TITLE
Docs: Add Getting started guidelines for subcomponents

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,3 +110,11 @@ Questions, feedback, and suggestions are welcomed on the
 channel on `CNCF Slack <https://slack.cncf.io/>`_.
 
 .. _ROADMAP: ROADMAP.rst
+
+Contributing: Getting Started
+=============================
+
+To configure RSTUF components for development, please see the contributing guidelines:
+* Getting Started with `repository-service-tuf-cli <https://github.com/repository-service-tuf/repository-service-tuf-cli/blob/main/CONTRIBUTING.rst>`_
+* Getting Started with `repository-service-tuf-api <https://github.com/repository-service-tuf/repository-service-tuf-api/blob/main/README.rst>`_
+* Getting Started with `repository-service-tuf-worker <https://github.com/repository-service-tuf/repository-service-tuf-worker/blob/main/README.rst>`_

--- a/docs/source/guide/deployment/setup.rst
+++ b/docs/source/guide/deployment/setup.rst
@@ -161,7 +161,7 @@ connected to RSTUF API. It does not require a
 
     .. code::
 
-        ❯ rstuf admin login
+        ❯ rstuf --auth admin login
         ❯ rstuf admin ceremony -b
 
 

--- a/docs/source/guide/repository-service-tuf-cli/index.rst
+++ b/docs/source/guide/repository-service-tuf-cli/index.rst
@@ -69,7 +69,7 @@ such as Ceremony, Token Generation, etc.
 
 .. code:: shell
 
-    ❯ rstuf admin login
+    ❯ rstuf --auth admin login
     ╔══════════════════════════════════════════════════════════════════════════════════════╗
     ║                     Login to Repository Service for TUF                              ║
     ╚══════════════════════════════════════════════════════════════════════════════════════╝


### PR DESCRIPTION
This change adds a Contributing getting started section with links
to the subcomponents getting started guidelines for development
and fixes the `rstuf admin login` command in docs with the
missing `--auth` flag

Fixes #466 
