### PR TITLE
Add to `ft-base.sh` option install CLI from source

### DIFF
--- a/tests/functional/scripts/ft-base.sh
+++ b/tests/functional/scripts/ft-base.sh
@@ -17,6 +17,10 @@ case ${CLI_VERSION} in
         pip install --upgrade repository-service-tuf
         ;;
 
+    source) # it install froom the source code (used by CLI)
+        pip install -e .
+        ;;
+
     *) # dev or none
         pip install git+https://github.com/repository-service-tuf/repository-service-tuf-cli
         ;;


### PR DESCRIPTION
Add to `ft-base.sh` script, which install the dependencies and CLI an option to install from source code.

It will be used by repository-service-tuf-cli component.