### PR TITLE
build: custom metadata base url on functional test

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -65,10 +65,10 @@ def get_target_info():
         # rename 1.root.json to root.json
         path = os.path.join(temp_md_dir.name, "root.json")
         shutil.copy(os.path.join("metadata", "1.root.json"), path)
-
+        metadata_base_url = os.getenv("METADATA_BASE_URL") or "http://web:8080"
         updater = Updater(
             metadata_dir=temp_md_dir.name,
-            metadata_base_url="http://web:8080",
+            metadata_base_url=metadata_base_url,
             config=UpdaterConfig(prefix_targets_with_hash=False),
         )
         updater.refresh()


### PR DESCRIPTION
It gives a simple way to run functional tests using the TUF Client's custom metadata base URL.

The FT uses a TUF Client (python-tuf, ngclient) to verify the metadata consistency.
For some custom tests where the Metadata Base URL can have a custom address, the developer/tester can call giving an environment variable `METADATA_BASE_URL` and use it to run the tests.