### PR TITLE
build: fix CI and docs workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,22 @@ on:
       - main
     paths-ignore:
       - 'docs/**'
+      - "TAC.rst"
+      - "CODE_OF_CONDUCT.rst"
+      - "LICENSE"
+      - "MAINTAINERS.rst"
+      - "README.rst"
+      - "ROADMAP.rst"
 
   pull_request:
     paths-ignore:
       - 'docs/**'
+      - "TAC.rst"
+      - "CODE_OF_CONDUCT.rst"
+      - "LICENSE"
+      - "MAINTAINERS.rst"
+      - "README.rst"
+      - "ROADMAP.rst"
 
   workflow_dispatch:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,12 @@ on:
       - opened
     paths:
       - "docs/**"
+      - "TAC.rst"
+      - "CODE_OF_CONDUCT.rst"
+      - "LICENSE"
+      - "MAINTAINERS.rst"
+      - "README.rst"
+      - "ROADMAP.rst"
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
There are several documentation files in the root folder that doesn't require to trigger FT when they are changed.

Closes #505 