### PR TITLE
Migrate FT to use /api/v1/artifacts

### DIFF
--- a/tests/functional/targets/test_add_targets.py
+++ b/tests/functional/targets/test_add_targets.py
@@ -49,7 +49,7 @@ def the_api_requester_adds_a_new_target(
         custom = ast.literal_eval(custom)
         payload["targets"][0]["info"].update({"custom": custom})
 
-    return http_request(method="POST", url="/api/v1/targets", json=payload)
+    return http_request(method="POST", url="/api/v1/artifacts", json=payload)
 
 
 @then(

--- a/tests/functional/targets/test_performance.py
+++ b/tests/functional/targets/test_performance.py
@@ -50,7 +50,7 @@ def send_requests_with_targets(num_requests, num_targets, http_request):
 
         result = http_request(
             "POST",
-            url="/api/v1/targets",
+            url="/api/v1/artifacts",
             json={"targets": targets},
         )
         return result

--- a/tests/functional/targets/test_remove_targets.py
+++ b/tests/functional/targets/test_remove_targets.py
@@ -51,7 +51,9 @@ def there_are_targets_available_for_download(
             }
         )
 
-    response = http_request(method="POST", url="/api/v1/targets", json=payload)
+    response = http_request(
+        method="POST", url="/api/v1/artifacts", json=payload
+    )
     assert response.status_code == 202, response.text
     threshold = 90
     task_completed_within_threshold(http_request, response.json(), threshold)
@@ -69,7 +71,7 @@ def the_api_requester_deletes_targets(http_request, paths):
     # remove quotes; example "[str, str]" -> [str, str]
     paths = ast.literal_eval(paths)
     payload = {"targets": paths}
-    return http_request(method="DELETE", url="/api/v1/targets", json=payload)
+    return http_request(method="DELETE", url="/api/v1/artifacts", json=payload)
 
 
 @then(
@@ -131,7 +133,7 @@ def the_api_requester_tries_to_delete_all_targets(
     paths = ast.literal_eval(paths)
     non_existing_paths = ast.literal_eval(non_existing_paths)
     payload = {"targets": paths + non_existing_paths}
-    return http_request(method="DELETE", url="/api/v1/targets", json=payload)
+    return http_request(method="DELETE", url="/api/v1/artifacts", json=payload)
 
 
 @then(


### PR DESCRIPTION
The RSTUF API migrate the `/api/v1/targets` to `/api/v1/artifacts` to have a better names for the user experience.

In the TUF Specification and internals we use `Targets`, but it can be confused to RSTUF/ user.