### PR TITLE
fix: ft recurring error for test

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -99,10 +99,8 @@ def task_completed_within_threshold():
             result = task_response_json["data"].get("result")
             if result is not None:
                 # "status" is missing when the task is in its earliest stage
-                status = result.get("status")
-
-            if status is True:
-                break
+                if result.get("status") is True:
+                    break
 
         perfomance_fail = os.getenv("PERFORMANCE", "true").lower() == "true"
         if (


### PR DESCRIPTION
The `result[status]` is missing and raises an exception.

The status can be missing in early task stage