### PR TITLE
Enable run FT from umbrella locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,20 @@
 .PHONY: docs lint reformat requirements functional-tests sync-submodules
 
+run-dev: export API_VERSION=dev
+run-dev: export WORKER_VERSION=dev
+run-dev:
+	docker compose up -d
+
+stop:
+	docker compose down -v
+
+clean:
+	$(MAKE) stop
+	docker compose rm --force
+	rm -rf ./data
+	rm -rf ./data_test
+
+
 sync-submodules:
 	git submodule sync
 	git submodule update --init --force --recursive
@@ -44,3 +59,18 @@ functional-tests-exitfirst:
 
 functional-tests:
 	pytest --gherkin-terminal-reporter tests -vvv --cucumberjson=test-report.json --durations=0 --html=test-report.html
+
+
+ft-das:
+ifneq ($(CLI),)
+	docker compose run --env UMBRELLA_PATH=. --rm rstuf-ft-runner bash tests/functional/scripts/run-ft-das.sh dev
+else
+	docker compose run --env UMBRELLA_PATH=. --rm rstuf-ft-runner bash tests/functional/scripts/run-ft-das.sh $(CLI)
+endif
+
+ft-signed:
+ifneq ($(CLI),)
+	docker compose run --env UMBRELLA_PATH=. --rm rstuf-ft-runner bash tests/functional/scripts/run-ft-signed.sh dev
+else
+	docker compose run --env UMBRELLA_PATH=. --rm rstuf-ft-runner bash tests/functional/scripts/run-ft-signed.sh $(CLI)
+endif

--- a/Makefile
+++ b/Makefile
@@ -61,16 +61,18 @@ functional-tests:
 	pytest --gherkin-terminal-reporter tests -vvv --cucumberjson=test-report.json --durations=0 --html=test-report.html
 
 
+# CLI_VERSION enables using specific RSTUF CLI version, default: dev
+# usage: `make ft-das CLI_VERSION=v0.8.0b1`
 ft-das:
-ifneq ($(CLI),)
+ifneq ($(CLI_VERSION),)
 	docker compose run --env UMBRELLA_PATH=. --rm rstuf-ft-runner bash tests/functional/scripts/run-ft-das.sh dev
 else
-	docker compose run --env UMBRELLA_PATH=. --rm rstuf-ft-runner bash tests/functional/scripts/run-ft-das.sh $(CLI)
+	docker compose run --env UMBRELLA_PATH=. --rm rstuf-ft-runner bash tests/functional/scripts/run-ft-das.sh $(CLI_VERSION)
 endif
 
 ft-signed:
-ifneq ($(CLI),)
+ifneq ($(CLI_VERSION),)
 	docker compose run --env UMBRELLA_PATH=. --rm rstuf-ft-runner bash tests/functional/scripts/run-ft-signed.sh dev
 else
-	docker compose run --env UMBRELLA_PATH=. --rm rstuf-ft-runner bash tests/functional/scripts/run-ft-signed.sh $(CLI)
+	docker compose run --env UMBRELLA_PATH=. --rm rstuf-ft-runner bash tests/functional/scripts/run-ft-signed.sh $(CLI_VERSION)
 endif

--- a/docs/source/devel/development.rst
+++ b/docs/source/devel/development.rst
@@ -132,7 +132,7 @@ It is possible to run Functional Tests (FT) from each component, including the
 Umbrella repository.
 
 1. Start the development deployment ``make run-dev``
-2. Start the functional test  ``make ft-<type>`` (Check the ``Makefile`` to
+2. Start the functional tests  ``make ft-<type>`` (Check ``Makefile`` to
    see the available types of tests).
 
 The functional tests has global environment variables that can be used:

--- a/docs/source/devel/development.rst
+++ b/docs/source/devel/development.rst
@@ -137,7 +137,7 @@ Umbrella repository.
 
 The functional tests has global environment variables that can be used:
 
-- ``PERFORMANCE``: ``bool``, it disable the failure in case of low performance
+- ``PERFORMANCE``: ``bool``, it disables the failure in case of low performance
   timeout. It is used to test only the consistency.
 
 - ``METADATA_BASE_URL``: to use some custom metatada base url in the TUF

--- a/docs/source/devel/development.rst
+++ b/docs/source/devel/development.rst
@@ -110,6 +110,7 @@ A new BDD Feature file for an unexisting RSTUF Feature is always merged into a
 feature branch. After discussing the new feature request, the feature branch is
 created upon request by the maintainers.
 
+
 Tooling
 .......
 
@@ -123,6 +124,27 @@ The BDD tests have the workflow also in the `Umbrella repository
 <http://github.com/repository-service-tuf/repository-service-tuf>`_ , as a reusable
 GitHub Workflow, and it is triggered by other workflows/components i.e.,
 before releasing.
+
+Running Functional Tests
+........................
+
+It is possible to run Functional Tests (FT) from each component, including the
+Umbrella repository.
+
+1. Start the development deployment ``make run-dev``
+2. Start the functional test  ``make ft-<type>`` (Check the ``Makefile`` to
+   see the available types of tests).
+
+The functional tests has global environment variables that can be used:
+
+- ``PERFORMANCE``: ``bool``, it disable the failure in case of low performance
+  timeout. It is used to test only the consistency.
+
+- ``METADATA_BASE_URL``: to use some custom metatada base url in the TUF
+  Client. Default is  ``http://web:8080``
+
+This environment variables needs to be passed to the container that calls
+the ``pytest`` or ``ft-<name>`` scripts.
 
 
 Project organization


### PR DESCRIPTION
It adds to the Makefile the commands to run the FT from the umbrella repository source code.

<!-- readthedocs-preview repository-service-tuf start -->
----
:books: Documentation preview :books:: https://repository-service-tuf--513.org.readthedocs.build/en/513/

<!-- readthedocs-preview repository-service-tuf end -->