### PR TITLE
tests: FT metadata update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
 # RSTUF Specifics
 test-report.html
 test-report.json
-metadata/
+./metadata/
 payload.json
 .rstuf.yml
 assets/
+metadata-update-payload.json
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+log_cli = true
+log_cli_level = INFO
+log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
+log_cli_date_format=%Y-%m-%d %H:%M:%S

--- a/tests/features/metadata/update.feature
+++ b/tests/features/metadata/update.feature
@@ -1,0 +1,12 @@
+Feature: Update metadata
+    User has deployed RSTUF,
+    User has run the ceremony and completed bootstrap successfully,
+
+    Scenario: Updating Root metadata full signed
+        Given RSTUF is running and operational
+        Then the RSTUF is receiving multiple requests
+        When the RSTUF key holders send a full signed metadata
+        Then the API requester should get status code '202' with 'task_id'
+        Then the API requester gets from endpoint 'GET /api/v1/task' status 'SUCCESS'
+        Then the '2.root.json' will be available in the TUF Metadata
+        Then the user downloads will not have inconsistency during this process

--- a/tests/features/metadata/update.feature
+++ b/tests/features/metadata/update.feature
@@ -5,7 +5,7 @@ Feature: Update metadata
     Scenario: Updating Root metadata full signed
         Given RSTUF is running and operational
         Then the RSTUF is receiving multiple requests
-        When the RSTUF key holders send a full signed metadata
+        When the RSTUF key holders send a fully signed metadata
         Then the API requester should get status code '202' with 'task_id'
         Then the API requester gets from endpoint 'GET /api/v1/task' status 'SUCCESS'
         Then the '2.root.json' will be available in the TUF Metadata

--- a/tests/functional/metadata/test_update.py
+++ b/tests/functional/metadata/test_update.py
@@ -1,0 +1,181 @@
+"""Update metadata feature tests."""
+
+import json
+import logging
+import os
+import threading
+import time
+
+import names_generator
+import pytest
+from pytest_bdd import given, scenario, then, when
+
+LOGGER = logging.getLogger(__name__)
+
+pytest.rstuf_added_targets = []
+pytest.rstuf_thread = None
+
+
+def rstuf_requests(stop_requests, http_request):
+    while not stop_requests.is_set():
+        targets = []
+        LOGGER.info("Adding artifacts")
+        for count in range(0, int(10)):
+            filename = f"test/{names_generator.generate_name()}-{count}.tar.gz"
+            target = {
+                "info": {
+                    "length": 54321,
+                    "hashes": {
+                        "blake2b-256": (
+                            "716f6e863f744b9ac22c97ec7b76ea5f5908bc5b2f67c6151"
+                            "0bfc4751384ea7a"
+                        )
+                    },
+                },
+                "path": filename,
+            }
+            targets.append(target)
+
+        result = http_request(
+            "POST",
+            url="/api/v1/artifacts",
+            json={"targets": targets},
+        )
+        data_result = result.json()["data"]
+        LOGGER.info(f"Added task_id: {data_result['task_id']}")
+        pytest.rstuf_added_targets.append(result.json())
+        time.sleep(0.5)
+
+    LOGGER.info(
+        "Stop adding artifacts. "
+        f"Total requests: {len(pytest.rstuf_added_targets )}"
+    )
+
+
+@scenario(
+    "../../features/metadata/update.feature",
+    "Updating Root metadata full signed",
+)
+def test_updating_root_metadata_full_signed():
+    """Updating Root metadata full signed."""
+
+
+@given("RSTUF is running and operational")
+def running_multiple_requests():
+    pass
+
+
+@then(
+    "the RSTUF is receiving multiple requests",
+    target_fixture="send_rstuf_requests",
+)
+def rstuf_receiving_requests(http_request):
+    stop_requests = threading.Event()
+    thread = threading.Thread(
+        target=rstuf_requests, args=(stop_requests, http_request)
+    )
+    thread.start()
+    return stop_requests
+
+
+@when(
+    "the RSTUF key holders send a full signed metadata",
+    target_fixture="response",
+)
+def send_signed_update_metadata(send_rstuf_requests, http_request):
+    # Start thread sending requests to add artifacts
+    pytest.rstuf_thread = send_rstuf_requests
+    # Wait some requests in the broker before run metadata update
+    time.sleep(2)
+    LOGGER.info("[METADATA UPDATE] Submiting Root Metadata Update")
+    with open("metadata-update-payload.json") as f:
+        paylaod_json = json.loads(f.read())
+
+    result = http_request(
+        "POST",
+        url="/api/v1/metadata",
+        json=paylaod_json,
+    )
+    return result
+
+
+@then(
+    "the API requester should get status code '202' with 'task_id'",
+    target_fixture="task_id",
+)
+def task_is_received(response):
+    assert response.status_code == 202, pytest.rstuf_thread.set()
+
+    json_response = response.json()
+    task_id = json_response["data"]["task_id"]
+    LOGGER.info(f"[METADATA UPDATE]  Metadata Updated by {task_id}")
+    return task_id
+
+
+@then(
+    "the API requester gets from endpoint 'GET /api/v1/task' status 'SUCCESS'"
+)
+def task_is_finished(task_id, http_request):
+    count = 0
+
+    # check for the metadata update task
+    while count < 60:
+        response = http_request(
+            "GET",
+            url=f"/api/v1/task/?task_id={task_id}",
+        )
+
+        data = response.json()["data"]
+        state = data.get("state", None)
+        status = data.get("result", {}).get("status")
+        if state == "SUCCESS":
+            LOGGER.info(f"[METADATA UPDATE] {response.text}")
+            assert status is True, pytest.rstuf_thread.set()
+            break
+        else:
+            count += 1
+            time.sleep(0.5)
+
+    LOGGER.info("[METADATA UPDATE] Update Metadata to 2.root.json finished")
+    assert count < 60, pytest.rstuf_thread.set()
+    time.sleep(2)
+    pytest.rstuf_thread.set()
+
+
+@then("the '2.root.json' will be available in the TUF Metadata")
+def root_metadata_2_root_is_available(http_request):
+    # double check if the new version is available in the metadata storage
+    metadata_base_url = os.getenv("METADATA_BASE_URL") or "http://web:8080"
+    count = 0
+    while count < 60:
+        response = http_request(
+            "GET",
+            host=metadata_base_url,
+        )
+        if "2.root.json" in response.text:
+            break
+        else:
+            count += 1
+            time.sleep(0.5)
+    LOGGER.info("[METADATA UPDATE] Metadata Update available (2.root.json)")
+    assert count < 60, pytest.rstuf_thread.set()
+
+
+@then("the user downloads will not have inconsistency during this process")
+def verify_targets_consistency(
+    get_target_info, http_request, task_completed_within_threshold
+):
+    # wait all artifact tasks to be complete and check the consistency
+    count = 1
+    for response_json in pytest.rstuf_added_targets:
+        task_completed_within_threshold(http_request, response_json, 180)
+        LOGGER.info(f"Task {count}/{len(pytest.rstuf_added_targets)} finshed!")
+        count += 1
+
+    for response_json in pytest.rstuf_added_targets:
+        for target in response_json["data"].get("targets"):
+            LOGGER.info(f"Verifying {target}")
+            assert target is not None, pytest.rstuf_thread.set()
+            assert (
+                get_target_info(target) is not None
+            ), pytest.rstuf_thread.set()

--- a/tests/functional/metadata/test_update.py
+++ b/tests/functional/metadata/test_update.py
@@ -20,7 +20,7 @@ def rstuf_requests(stop_requests, http_request):
     while not stop_requests.is_set():
         targets = []
         LOGGER.info("Adding artifacts")
-        for count in range(0, int(10)):
+        for count in range(10):
             filename = f"test/{names_generator.generate_name()}-{count}.tar.gz"
             target = {
                 "info": {

--- a/tests/functional/metadata/test_update.py
+++ b/tests/functional/metadata/test_update.py
@@ -79,7 +79,7 @@ def rstuf_receiving_requests(http_request):
 
 
 @when(
-    "the RSTUF key holders send a full signed metadata",
+    "the RSTUF key holders send a fully signed metadata",
     target_fixture="response",
 )
 def send_signed_update_metadata(send_rstuf_requests, http_request):

--- a/tests/functional/metadata/test_update.py
+++ b/tests/functional/metadata/test_update.py
@@ -138,6 +138,7 @@ def task_is_finished(task_id, http_request):
 
     LOGGER.info("[METADATA UPDATE] Update Metadata to 2.root.json finished")
     assert count < 60, pytest.rstuf_thread.set()
+    # wait add artifacts continue 2 seconds after metadata update has finished
     time.sleep(2)
     pytest.rstuf_thread.set()
 

--- a/tests/functional/scripts/rstuf-admin-ceremony.py
+++ b/tests/functional/scripts/rstuf-admin-ceremony.py
@@ -10,7 +10,7 @@ from repository_service_tuf import Dynaconf, cli
 def _run(input):
     folder_name = mkdtemp()
     setting_file = os.path.join(folder_name, ".rstuf.yml")
-    context = {"settings": Dynaconf, "config": setting_file}
+    context = {"settings": Dynaconf(), "config": setting_file}
     runner = CliRunner()
     output = runner.invoke(
         cli.admin.ceremony.ceremony,

--- a/tests/functional/scripts/rstuf-admin-metadata-update.py
+++ b/tests/functional/scripts/rstuf-admin-metadata-update.py
@@ -1,0 +1,49 @@
+import json
+import os
+import sys
+from tempfile import mkdtemp
+
+from click.testing import CliRunner
+from repository_service_tuf import Dynaconf, cli
+
+
+def _run(input):
+    folder_name = mkdtemp()
+    setting_file = os.path.join(folder_name, "rstuf.yml")
+    context = {"settings": Dynaconf(), "config": setting_file}
+    runner = CliRunner()
+    output = runner.invoke(
+        cli.admin.metadata.update,
+        "",
+        input="\n".join(input),
+        obj=context,
+        catch_exceptions=False,
+    )
+
+    return output
+
+
+def main():
+    input_dict = json.loads(sys.argv[1])
+    input = [i for i in input_dict.values()]
+
+    print("Using parameters:")
+    print(json.dumps(input_dict, indent=2))
+    output = _run(input)
+
+    print(f"\nExit code: {output.exit_code}")
+    print("\nOutput: ")
+    print(output.stdout)
+    if output.stderr_bytes is not None:
+        print(f"\nError\n: {output.stderr}")
+
+    if output.exception:
+        print(f"Exception: {output.exception}")
+        print(f"Exception Info: {output.exc_info}")
+        output.exc_info
+
+    sys.exit(output.exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/functional/scripts/run-ft-das.sh
+++ b/tests/functional/scripts/run-ft-das.sh
@@ -68,4 +68,20 @@ if [[ ${UMBRELLA_PATH} != "." ]]; then
     cp -r metadata ${UMBRELLA_PATH}/
 fi
 
+# Run metadata update to be used later (during FT)
+python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-metadata-update.py '{
+    "File name or URL to the current root metadata": "metadata/1.root.json",
+    "(Authz threshold 1/2) Choose root key type [ed25519/ecdsa/rsa] (ed25519)": "",
+    "(Authz threshold 1/2) Enter the root`s private key path": "tests/files/key_storage/JanisJoplin.key",
+    "(Authz threshold 1/2) Enter the root`s private key password": "strongPass",
+    "(Authz threshold 2/2) Choose root key type [ed25519/ecdsa/rsa] (ed25519)": "",
+    "(Authz threshold 2/2) Enter the root`s private key path": "tests/files/key_storage/JimiHendrix.key",
+    "(Authz threshold 2/2) Enter the root`s private key password": "strongPass",
+    "Do you want to extend the root`s expiration?": "y",
+    "Days to extend root`s expiration starting from today (365)": "",
+    "New root expiration: YYYY-M-DD. Do you agree?": "y",
+    "Do you want to modify root keys? [y/n]": "n",
+    "Do you want to change the online key?": "n"
+}'
+
 make -C ${UMBRELLA_PATH}/ functional-tests-exitfirst

--- a/tests/functional/scripts/run-ft-signed.sh
+++ b/tests/functional/scripts/run-ft-signed.sh
@@ -49,4 +49,19 @@ if [[ ${UMBRELLA_PATH} != "." ]]; then
     cp -r metadata ${UMBRELLA_PATH}/
 fi
 
+python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-metadata-update.py '{
+    "File name or URL to the current root metadata": "metadata/1.root.json",
+    "(Authz threshold 1/2) Choose root key type [ed25519/ecdsa/rsa] (ed25519)": "",
+    "(Authz threshold 1/2) Enter the root`s private key path": "tests/files/key_storage/JanisJoplin.key",
+    "(Authz threshold 1/2) Enter the root`s private key password": "strongPass",
+    "(Authz threshold 2/2) Choose root key type [ed25519/ecdsa/rsa] (ed25519)": "",
+    "(Authz threshold 2/2) Enter the root`s private key path": "tests/files/key_storage/JanisJoplin.key",
+    "(Authz threshold 2/2) Enter the root`s private key password": "strongPass",
+    "Do you want to extend the root`s expiration?": "y",
+    "Days to extend root`s expiration starting from today (365)": "",
+    "New root expiration: YYYY-M-DD. Do you agree?": "y",
+    "Do you want to modify root keys? [y/n]": "n",
+    "Do you want to change the online key?": "n"
+}'
+
 make -C ${UMBRELLA_PATH}/ functional-tests-exitfirst


### PR DESCRIPTION
Adds interactive run of the metadata update feature and the test
implementation.

The process works by:

- It creates a thread sending "add artifacts"
- It waits for some tasks to be sent to the broker and runs the
  "metadata update" request.
- It checks if the metadata update task finishes and waits to receive
  more tasks and stop the thread "add artifacts"
- It validates if the new 2.root.json is in the metadata storage
- It waits for all "add artifacts" tasks to finish
- It validates if the TUF client finds all artifacts to guarantee the
  consistency

This includes interactive metadata updates using the CLI to create the
the payload for `metadata update`
It will allow the future use of the DAS for metadata updates in some
scenario of FT