### PR TITLE
Add breaking changes from API and CLI to RSTUF

### DIFF
--- a/tests/functional/bootstrap/test_bootstrap.py
+++ b/tests/functional/bootstrap/test_bootstrap.py
@@ -20,7 +20,7 @@ def the_tufrepositoryservice_rstufcli_is_installed(rstuf_cli):
 @when("the admin run rstuf for ceremony bootstrap", target_fixture="bootstrap")
 def the_administrator_uses_rstufcli_bootstrap(rstuf_cli):
     rc, output = rstuf_cli(
-        "admin ceremony -b -u -f payload.json --upload-server "
+        "admin ceremony -b -u -f payload.json --api-server "
         "http://repository-service-tuf-api"
     )
     return rc, output
@@ -55,7 +55,7 @@ def test_bootstrap_using_rstuf_cli_with_invalid_payload():
 def the_administrator_uses_rstufcli_bootstrap_invalid_payload(rstuf_cli):
     rc, output = rstuf_cli(
         "admin ceremony -b -u -f tests/data/payload-invalid.json "
-        "--upload-server http://repository-service-tuf-api"
+        "--api-server http://repository-service-tuf-api"
     )
 
     return rc, output

--- a/tests/functional/scripts/run-ft-das.sh
+++ b/tests/functional/scripts/run-ft-das.sh
@@ -46,7 +46,7 @@ python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-ceremony.py '{
 }'
 
 # Bootstrap using DAS
-rstuf admin ceremony -b -u -f payload.json --upload-server http://repository-service-tuf-api
+rstuf admin ceremony -b -u -f payload.json --api-server http://repository-service-tuf-api
 
 
 # Finish the DAS signing the Root Metadata (bootstrap)

--- a/tests/functional/scripts/run-ft-signed.sh
+++ b/tests/functional/scripts/run-ft-signed.sh
@@ -40,7 +40,7 @@ python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-ceremony.py '{
 }'
 
 # Bootstrap using full signed payload
-rstuf admin ceremony -b -u -f payload.json --upload-server http://repository-service-tuf-api
+rstuf admin ceremony -b -u -f payload.json --api-server http://repository-service-tuf-api
 
 # Get initial trusted Root
 rm metadata/1.root.json


### PR DESCRIPTION
It adds the following changes from the API and CLI

- CLI: bootstrap updated `--upload-server` to `--api-server`
- API: `DELETE /api/v1/artifacts` to `POST /api/v1/artifacts/delete`

❗️Functionall Tests will fail