### PR TITLE
Apply new `.rstuf.yml` config file format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ test-report.html
 test-report.json
 metadata/
 payload.json
-rstuf.ini
+.rstuf.yml
 assets/
 
 # Byte-compiled / optimized / DLL files

--- a/tests/functional/scripts/rstuf-admin-ceremony.py
+++ b/tests/functional/scripts/rstuf-admin-ceremony.py
@@ -9,7 +9,7 @@ from repository_service_tuf import Dynaconf, cli
 
 def _run(input):
     folder_name = mkdtemp()
-    setting_file = os.path.join(folder_name, "rstuf.ini")
+    setting_file = os.path.join(folder_name, ".rstuf.yml")
     context = {"settings": Dynaconf, "config": setting_file}
     runner = CliRunner()
     output = runner.invoke(

--- a/tests/functional/scripts/rstuf-admin-metadata-sign.py
+++ b/tests/functional/scripts/rstuf-admin-metadata-sign.py
@@ -9,7 +9,7 @@ from repository_service_tuf import Dynaconf, cli
 
 def _run(input):
     folder_name = mkdtemp()
-    setting_file = os.path.join(folder_name, "rstuf.ini")
+    setting_file = os.path.join(folder_name, ".rstuf.yml")
     context = {"settings": Dynaconf(), "config": setting_file}
     runner = CliRunner()
     output = runner.invoke(


### PR DESCRIPTION
Change any references of `rstuf.ini` to
`.rstuf.yml` after the change in
https://github.com/repository-service-tuf/repository-service-tuf-cli/pull/419.