### PR TITLE
fix: ft triggered by components

### DIFF
--- a/tests/functional/scripts/run-ft-das.sh
+++ b/tests/functional/scripts/run-ft-das.sh
@@ -64,9 +64,6 @@ python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-metadata-sign.py '{
 rm metadata/1.root.json
 wget -P metadata/ http://web:8080/1.root.json
 
-if [[ ${UMBRELLA_PATH} != "." ]]; then
-    cp -r metadata ${UMBRELLA_PATH}/
-fi
 
 # Run metadata update to be used later (during FT)
 python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-metadata-update.py '{
@@ -83,5 +80,11 @@ python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-metadata-update.py 
     "Do you want to modify root keys? [y/n]": "n",
     "Do you want to change the online key?": "n"
 }'
+
+# Copy files when UMBRELLA_PATH is not the current dir (FT triggered from components)
+if [[ ${UMBRELLA_PATH} != "." ]]; then
+    cp -r metadata ${UMBRELLA_PATH}/
+    cp metadata-update-payload.json ${UMBRELLA_PATH}/
+fi
 
 make -C ${UMBRELLA_PATH}/ functional-tests-exitfirst

--- a/tests/functional/scripts/run-ft-signed.sh
+++ b/tests/functional/scripts/run-ft-signed.sh
@@ -45,9 +45,6 @@ rstuf admin ceremony -b -u -f payload.json --api-server http://repository-servic
 # Get initial trusted Root
 rm metadata/1.root.json
 wget -P metadata/ http://web:8080/1.root.json
-if [[ ${UMBRELLA_PATH} != "." ]]; then
-    cp -r metadata ${UMBRELLA_PATH}/
-fi
 
 python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-metadata-update.py '{
     "File name or URL to the current root metadata": "metadata/1.root.json",
@@ -63,5 +60,11 @@ python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-metadata-update.py 
     "Do you want to modify root keys? [y/n]": "n",
     "Do you want to change the online key?": "n"
 }'
+
+# Copy files when UMBRELLA_PATH is not the current dir (FT triggered from components)
+if [[ ${UMBRELLA_PATH} != "." ]]; then
+    cp -r metadata ${UMBRELLA_PATH}/
+    cp metadata-update-payload.json ${UMBRELLA_PATH}/
+fi
 
 make -C ${UMBRELLA_PATH}/ functional-tests-exitfirst


### PR DESCRIPTION
When a component triggers the FT, all generated files required by BDD tests must be in the `${UMBRELLA_PATH}` current folder. It includes:
- metadata folder (used by tuf-client)
- metadata-update-payload.json

Include pytest-xdist to improve the speed triggering the FT in parallel