### PR TITLE
fix: `make requirements` should update `Pipfile.lock`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ docs:
 	sphinx-build -T -E -b html docs/source docs/build/html
 
 requirements:
+	pipenv lock
 	pipenv requirements > requirements.txt
 
 reformat:


### PR DESCRIPTION
We expect the requirements files to include the latest changes made to the Pipfile.
This does not happen since we need to lock before. This is because the `Pipfile.lock` is used to generate the requirement files, source:
https://pipenv.pypa.io/en/latest/advanced/#generating-a-requirements-txt