### PR TITLE
Updating ROADMAP for MVP

### DIFF
--- a/ROADMAP.rst
+++ b/ROADMAP.rst
@@ -64,12 +64,13 @@ First Production Deploy
 This release achieves the minimum valuable product for users.
 
 - [x] Deployment Design Document (`Issue #227 <https://github.com/repository-service-tuf/repository-service-tuf/issues/227>`_)
-- [ ] Distributed asynchronous threshold signing (`Issue #327 <https://github.com/repository-service-tuf/repository-service-tuf/issues/327>`_)
-- [ ] Support to AWS S3 (Storage) and AWS KMS (Key Vault) (`Issue #24 <https://github.com/repository-service-tuf/repository-service-tuf/issues/24>`_)
-- [ ] Support CLI using HSM for signing - Ceremony, Metadata Update and Sign (`Issue #351[cli] <https://github.com/repository-service-tuf/repository-service-tuf-cli/issues/351>`_)
+- [x] Support to AWS S3 (Storage) (`Issue # <https://github.com/repository-service-tuf/repository-service-tuf/issues/24>`)
+- [ ] AWS KMS (Key Vault) (`Issue #24 <https://github.com/repository-service-tuf/repository-service-tuf/issues/24>`_)
 - [ ] Support of HashiCorp Vault (`Issue #509 <https://github.com/repository-service-tuf/repository-service-tuf/issues/509>`_)
+- [ ] Distributed asynchronous threshold signing (`Issue #327 <https://github.com/repository-service-tuf/repository-service-tuf/issues/327>`_)
+- [ ] Support CLI using HSM for signing - Ceremony, Metadata Update and Sign (`Issue #351[cli] <https://github.com/repository-service-tuf/repository-service-tuf-cli/issues/351>`_)
+- [ ] Create/Remove custom delegate Target Roles (`Issue #354 <https://github.com/repository-service-tuf/repository-service-tuf/issues/354>`_)
 - [ ] Security Audit on RSTUF Project  (`Issue #246 <https://github.com/repository-service-tuf/repository-service-tuf/issues/546>`_)
-- [ ] Old Metadata retention (`Issue #29 <https://github.com/repository-service-tuf/repository-service-tuf/issues/29>`_)
 
 Components Milestones:
 


### PR DESCRIPTION
Hi folks,

We are getting close to our 1.0.0, and here is my suggestion for the final MVP roadmap.

* AWS S3 support is completed 🎉 
* Added support to add custom delegation target roles. It is important because two use cases
  - Not all TUF client libraries implementation supports target hash bin delegations (TUF TAP 15).
  - It will support more custom TUF repositories designs

A fantastic refactoring is going on by @lukpueh about improving the use of SecureSystemsLib (SSLib) in RSTUF. It will empower easy adoption of signers directly from SSLib. For example, it will make having HashiCorp Vault easier when enabled in the SSLib and HSM (i.e., Yubikey) signing in the RSTUF Command-Line.

* Old Metadata retention is not a `must have` for RSTUF, and Custome Delegation Roles replaced it

<!-- readthedocs-preview repository-service-tuf start -->
----
📚 Documentation preview 📚: https://repository-service-tuf--604.org.readthedocs.build/en/604/

<!-- readthedocs-preview repository-service-tuf end -->