### PR TITLE
Add case for local running of `functional-tests-exitfirst`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,10 @@ lint:
 	rm requirements.commit
 
 functional-tests-exitfirst:
-ifeq ($(SLOW),)
+ifneq ($(GITHUB_ACTION),)
+	echo "Running tests locally"
+	pytest --exitfirst --gherkin-terminal-reporter tests -vvv --cucumberjson=test-report.json --durations=0 --html=test-report.html
+else ($(SLOW),)
 	echo "Running fast tests"
 	# `splits` and the `pytest-group` matrix on CI should match
 	pytest --exitfirst --splits 3 --group $(PYTEST_GROUP) --store-durations --durations-path=./.test_durations.$(PYTEST_GROUP) --deselect=tests/functional/artifacts/test_performance.py::test_api_requester_multiple_request_and_artifacts[50-50-600] tests -vvv --cucumberjson=test-report.json --durations=0 --html=test-report.html

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ functional-tests-exitfirst:
 ifneq ($(GITHUB_ACTION),)
 	echo "Running tests locally"
 	pytest --exitfirst --gherkin-terminal-reporter tests -vvv --cucumberjson=test-report.json --durations=0 --html=test-report.html
-else ($(SLOW),)
+else ifeq ($(SLOW),)
 	echo "Running fast tests"
 	# `splits` and the `pytest-group` matrix on CI should match
 	pytest --exitfirst --splits 3 --group $(PYTEST_GROUP) --store-durations --durations-path=./.test_durations.$(PYTEST_GROUP) --deselect=tests/functional/artifacts/test_performance.py::test_api_requester_multiple_request_and_artifacts[50-50-600] tests -vvv --cucumberjson=test-report.json --durations=0 --html=test-report.html


### PR DESCRIPTION
If we are not running `functional-tests-exitfirst` on GH actions we don't run the tests in different groups.

Related to https://github.com/repository-service-tuf/repository-service-tuf-worker/pull/493