### PR TITLE
Fix ft tests by making sure we have an output in case of error

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -21,9 +21,8 @@ def rstuf_cli():
             capture_output=True,
         )
 
-        return result.returncode, ansi_escape.sub(
-            "", result.stdout.decode("utf-8")
-        )
+        output = result.stdout if len(result.stdout) > 0 else result.stderr
+        return result.returncode, ansi_escape.sub("", output.decode("utf-8"))
 
     return _run_rstuf_cli
 


### PR DESCRIPTION
Fix ft tests.

This will make sure we return output even if we have an error.

Signed-off-by: Martin Vrachev <martin.vrachev@broadcom.com>
