### PR TITLE
FT tests: use new `ceremony` and `sign` options & bootstrap with new `ceremony`

### DIFF
--- a/docs/source/guide/deployment/setup.rst
+++ b/docs/source/guide/deployment/setup.rst
@@ -78,14 +78,15 @@ TUF service.
             :ref:`guide/deployment/setup:Ceremony`.
 
         .. note::
-            RSTUF requires at least the threshold number of Root key(s) for
+            RSTUF requires at least a threshold number of Root key(s) defined
+            to finish the ceremony. The same applies when performing
             :ref:`guide/general/usage:Metadata Update`.
 
 
     * Root key threshold
 
         The minimum number of keys required to update and sign the TUF Root
-        metadata.
+        metadata. It's required to be at least 2.
 
     * Targets, BINS, Snapshot, and Timestamp metadata expiration policy
 
@@ -122,7 +123,7 @@ separate step.
 
 .. code::
 
-    ❯ rstuf admin ceremony -s
+    ❯ rstuf admin ceremony --out
     Saved result to 'ceremony-payload.json'
 
 If the Ceremony is done disconnected, the next step is to perform the bootstrap.
@@ -131,18 +132,22 @@ If the Ceremony is done disconnected, the next step is to perform the bootstrap.
 Connected
 ---------
 
-.. note::
+The connected Ceremony generates the JSON payload file and run the Bootstrap
+request to RSTUF API.
 
-    Apollogies, this feature has been refactored and is not available in the
-    current version of the RSTUF CLI.
-    Please use the Ceremony :ref:`guide/deployment/setup:Disconnected`.
+This process is appropriate when performing the Ceremony on a computer
+connected to RSTUF API. It does not require a
+:ref:`guide/deployment/setup:Bootstrap` step.
+
+.. code::
+    ❯ rstuf admin --api-server https://rstuf-api-url ceremony
 
 
 Bootstrap
 =========
 
-.. If a Ceremony :ref:`guide/deployment/setup:Connected` is complete, skip this,
-.. as the RSTUF service is ready.
+If a Ceremony :ref:`guide/deployment/setup:Connected` is complete, skip this,
+as the RSTUF service is ready.
 
 To perform the boostrap you require the payload generated during the
 :ref:`guide/deployment/setup:Bootstrap`.
@@ -151,7 +156,7 @@ You can do it using the rstuf admin-legacy
 
 .. code::
 
-    ❯ rstuf admi-legacy ceremony -b -u -f ceremony-payload.json --api-url https://rstuf-api-url
+    ❯ rstuf admin-legacy ceremony -b -u -f ceremony-payload.json --api-url https://rstuf-api-url
     Starting online bootstrap
     Bootstrap status: ACCEPTED (c1d2356d25784ecf90ce373dc65b05c7)
     Bootstrap status:  STARTED

--- a/tests/functional/scripts/rstuf-admin-ceremony.py
+++ b/tests/functional/scripts/rstuf-admin-ceremony.py
@@ -14,7 +14,7 @@ def _run(input):
     runner = CliRunner()
     output = runner.invoke(
         cli.admin.ceremony.ceremony,
-        ["-s"],
+        ["--out"],
         input="\n".join(input),
         obj=context,
         catch_exceptions=False,

--- a/tests/functional/scripts/rstuf-admin-ceremony.py
+++ b/tests/functional/scripts/rstuf-admin-ceremony.py
@@ -10,7 +10,9 @@ from repository_service_tuf import Dynaconf, cli
 def _run(input):
     folder_name = mkdtemp()
     setting_file = os.path.join(folder_name, ".rstuf.yml")
-    context = {"settings": Dynaconf(), "config": setting_file}
+    test_settings = Dynaconf()
+    test_settings.SERVER = "http://repository-service-tuf-api"
+    context = {"settings": test_settings, "config": setting_file}
     runner = CliRunner()
     output = runner.invoke(
         cli.admin.ceremony.ceremony,

--- a/tests/functional/scripts/rstuf-admin-metadata-sign.py
+++ b/tests/functional/scripts/rstuf-admin-metadata-sign.py
@@ -10,11 +10,13 @@ from repository_service_tuf import Dynaconf, cli
 def _run(input):
     folder_name = mkdtemp()
     setting_file = os.path.join(folder_name, ".rstuf.yml")
-    context = {"settings": Dynaconf(), "config": setting_file}
+    test_settings = Dynaconf()
+    test_settings.SERVER = "http://repository-service-tuf-api"
+    context = {"settings": test_settings, "config": setting_file}
     runner = CliRunner()
     output = runner.invoke(
         cli.admin.sign.sign,
-        ["-s", "--api-server", "http://repository-service-tuf-api"],
+        ["--out"],
         input="\n".join(input),
         obj=context,
         catch_exceptions=False,

--- a/tests/functional/scripts/run-ft-das.sh
+++ b/tests/functional/scripts/run-ft-das.sh
@@ -16,7 +16,7 @@ else
     export METADATA_BASE_URL=http://localstack:4566/tuf-metadata
 fi
 
-# Execute the Ceremony using DAS
+# Execute the Ceremony using DAS and send result to RSTUF API
 python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-ceremony.py '{
     "Please enter days until expiry for timestamp role (1)": "",
     "Please enter days until expiry for snapshot role (1)": "",
@@ -41,9 +41,6 @@ python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-ceremony.py '{
     "(Sign 1) Please enter password": "hunter2",
     "(Sign 1) Please enter signing key index, or press enter to continue": "\n"
 }'
-
-# Bootstrap using legacy with DAS
-rstuf admin-legacy ceremony -b -u -f ceremony-payload.json --api-server http://repository-service-tuf-api
 
 # Finish the DAS signing the Root Metadata (bootstrap)
 python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-metadata-sign.py '{

--- a/tests/functional/scripts/run-ft-signed.sh
+++ b/tests/functional/scripts/run-ft-signed.sh
@@ -15,7 +15,7 @@ else
     export METADATA_BASE_URL=http://localstack:4566/tuf-metadata
 fi
 
-# Execute the Ceremony using DAS
+# Execute the Ceremony and Bootstrap RSTUF API
 python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-ceremony.py '{
     "Please enter days until expiry for timestamp role (1)": "",
     "Please enter days until expiry for snapshot role (1)": "",
@@ -39,10 +39,6 @@ python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-ceremony.py '{
     "(root 2) Please enter path to encrypted private key": "tests/files/key_storage/JH.ed25519",
     "(root 2) Please enter password": "hunter2"
 }'
-
-# Bootstrap using legacy with DAS
-rstuf admin-legacy ceremony -b -u -f ceremony-payload.json --api-server http://repository-service-tuf-api
-
 
 # Get initial trusted Root
 rm metadata/1.root.json


### PR DESCRIPTION
Update ft tests with two changes:
- use new `sign` and `ceremony` options
- bootstrap using new `admin ceremony`

Signed-off-by: Martin Vrachev <martin.vrachev@broadcom.com>