### PR TITLE
fix: ft bootstrap for components

### DIFF
--- a/tests/functional/scripts/run-ft-das.sh
+++ b/tests/functional/scripts/run-ft-das.sh
@@ -80,6 +80,7 @@ python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-metadata-update.py 
 # Copy files when UMBRELLA_PATH is not the current dir (FT triggered from components)
 if [[ ${UMBRELLA_PATH} != "." ]]; then
     cp update-payload.json ${UMBRELLA_PATH}/
+    cp ceremony-payload.json ${UMBRELLA_PATH}/
 fi
 
 make -C ${UMBRELLA_PATH}/ functional-tests-exitfirst PYTEST_GROUP=${PYTEST_GROUP} SLOW=${SLOW}

--- a/tests/functional/scripts/run-ft-signed.sh
+++ b/tests/functional/scripts/run-ft-signed.sh
@@ -66,6 +66,7 @@ python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-metadata-update.py 
 if [[ ${UMBRELLA_PATH} != "." ]]; then
     cp -r metadata ${UMBRELLA_PATH}/
     cp update-payload.json ${UMBRELLA_PATH}/
+    cp ceremony-payload.json ${UMBRELLA_PATH}/
 fi
 
 make -C ${UMBRELLA_PATH}/ functional-tests-exitfirst PYTEST_GROUP=${PYTEST_GROUP} SLOW=${SLOW}


### PR DESCRIPTION
While running the bootstrap FT it requires the ceremony-payload.json in the umbrella path, wich changes if the FT is running from umbrella or RSTUF components