### PR TITLE
test: fix metadata update output command

### DIFF
--- a/tests/functional/scripts/rstuf-admin-metadata-update.py
+++ b/tests/functional/scripts/rstuf-admin-metadata-update.py
@@ -21,7 +21,7 @@ def _run(input, selection):
 
     output = runner.invoke(
         cli.admin.update.update,
-        ["metadata/1.root.json", "-s"],
+        ["metadata/1.root.json", "--out"],
         input="\n".join(input),
         obj=context,
         catch_exceptions=False,


### PR DESCRIPTION
fix functional test to use the new `--out` parameter instead `-s`

It is proposed in: https://github.com/repository-service-tuf/repository-service-tuf-cli/pull/636