### PR TITLE
test: add parameter `--in` to specify the metadata

### DIFF
--- a/tests/functional/scripts/rstuf-admin-metadata-update.py
+++ b/tests/functional/scripts/rstuf-admin-metadata-update.py
@@ -21,7 +21,7 @@ def _run(input, selection):
 
     output = runner.invoke(
         cli.admin.update.update,
-        ["metadata/1.root.json", "--out"],
+        ["--in", "metadata/1.root.json", "--out"],
         input="\n".join(input),
         obj=context,
         catch_exceptions=False,


### PR DESCRIPTION
Add parameter `--in` to specify the root metadata