### PR TITLE
Fix ft tests

### DIFF
--- a/tests/features/metadata/update.feature
+++ b/tests/features/metadata/update.feature
@@ -8,5 +8,5 @@ Feature: Update metadata
         When the RSTUF key holders send a fully signed metadata
         Then the API requester should get status code '202' with 'task_id'
         Then the API requester gets from endpoint 'GET /api/v1/task' status 'SUCCESS'
-        Then the '2.root.json' will be available in the TUF Metadata
+        Then the '3.root.json' will be available in the TUF Metadata
         Then the user downloads will not have inconsistency during this process

--- a/tests/functional/metadata/test_update.py
+++ b/tests/functional/metadata/test_update.py
@@ -150,15 +150,17 @@ def task_is_finished(task_id, http_request):
             count += 1
             time.sleep(0.5)
 
-    LOGGER.info("[METADATA UPDATE] Update Metadata to 2.root.json finished")
+    # We have published two versions of root - one during bootstrap
+    # and one after "metadata update" prior to running ft tests.
+    LOGGER.info("[METADATA UPDATE] Update Metadata to 3.root.json finished")
     assert count < 60, pytest.rstuf_thread.set()
     # wait add artifacts continue 2 seconds after metadata update has finished
     time.sleep(2)
     pytest.rstuf_thread.set()
 
 
-@then("the '2.root.json' will be available in the TUF Metadata")
-def root_metadata_2_root_is_available(http_request):
+@then("the '3.root.json' will be available in the TUF Metadata")
+def root_metadata_3_root_is_available(http_request):
     # double check if the new version is available in the metadata storage
     metadata_base_url = os.getenv("METADATA_BASE_URL") or "http://web:8080"
     count = 0
@@ -167,12 +169,12 @@ def root_metadata_2_root_is_available(http_request):
             "GET",
             host=metadata_base_url,
         )
-        if "2.root.json" in response.text:
+        if "3.root.json" in response.text:
             break
         else:
             count += 1
             time.sleep(0.5)
-    LOGGER.info("[METADATA UPDATE] Metadata Update available (2.root.json)")
+    LOGGER.info("[METADATA UPDATE] Metadata Update available (3.root.json)")
     assert count < 60, pytest.rstuf_thread.set()
 
 


### PR DESCRIPTION
With the change in how we do metadata updates, we now fetch the latest root version.
Before we gave a URL to a specific root in this case root version 2, but actually, this was not the latest root and after we changed the the way we do "metadata update" the tests failed.

Signed-off-by: Martin Vrachev <martin.vrachev@gmail.com>