### PR TITLE
Ft das metadata update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # RSTUF Specifics
 test-report.html
 test-report.json
-metadata/
 payload.json
 update-payload.json
 ceremony-payload.json

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ lint:
 	rm requirements.commit
 
 functional-tests-exitfirst:
-ifneq ($(GITHUB_ACTION),)
+ifeq ($(GITHUB_ACTION),)
 	echo "Running tests locally"
 	pytest --exitfirst --gherkin-terminal-reporter tests -vvv --cucumberjson=test-report.json --durations=0 --html=test-report.html
 else ifeq ($(SLOW),)

--- a/tests/features/metadata/update.feature
+++ b/tests/features/metadata/update.feature
@@ -1,12 +1,13 @@
-Feature: Update metadata
+Feature: Metadata Update
     User has deployed RSTUF,
     User has run the ceremony and completed bootstrap successfully,
+    User has updated the metadata with the new version,
 
-    Scenario: Updating Root metadata full signed
+    Scenario: Metadata Update and Signing
         Given RSTUF is running and operational
         Then the RSTUF is receiving multiple requests
-        When the RSTUF key holders send a fully signed metadata
+        When the RSTUF Admin User send a metadata update
         Then the API requester should get status code '202' with 'task_id'
-        Then the API requester gets from endpoint 'GET /api/v1/task' status 'SUCCESS'
+        Then the Admin User runs the CLI to sign the metadata
         Then the '2.root.json' will be available in the TUF Metadata
         Then the user downloads will not have inconsistency during this process

--- a/tests/features/metadata/update.feature
+++ b/tests/features/metadata/update.feature
@@ -6,7 +6,7 @@ Feature: Metadata Update
     Scenario: Metadata Update and Signing
         Given RSTUF is running and operational
         Then the RSTUF is receiving multiple requests
-        When the RSTUF Admin User send a metadata update
+        When the RSTUF Admin User sends a metadata update
         Then the API requester should get status code '202' with 'task_id'
         Then the Admin User runs the CLI to sign the metadata
         Then the '2.root.json' will be available in the TUF Metadata

--- a/tests/functional/metadata/test_update.py
+++ b/tests/functional/metadata/test_update.py
@@ -83,7 +83,7 @@ def rstuf_receiving_requests(http_request):
 
 
 @when(
-    "the RSTUF Admin User send a metadata update",
+    "the RSTUF Admin User sends a metadata update",
     target_fixture="response",
 )
 def send_signed_update_metadata(send_rstuf_requests, http_request):

--- a/tests/functional/scripts/run-ft-das.sh
+++ b/tests/functional/scripts/run-ft-das.sh
@@ -72,9 +72,7 @@ python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-metadata-update.py 
   "[select] Select a key for signing (JanisJoplin/JimiHendrix)": "JanisJoplin",
   "(Sign 1) Please enter path to public key": "tests/files/key_storage/JJ.ecdsa",
   "(Sign 1) Please enter password": "hunter2",
-  "[select] Select a key for signing (continue/JimiHendrix)": "JimiHendrix",
-  "(Sign 2) Please enter path to public key": "tests/files/key_storage/JH.ed25519",
-  "(Sign 2) Please enter password": "hunter2"
+  "[select] Select a key for signing (continue/JimiHendrix)": "continue"
 }'
 
 # Copy files when UMBRELLA_PATH is not the current dir (FT triggered from components)


### PR DESCRIPTION
This commit implements to the FT the test for updating the root metadata with a not fully signed metadata.

The changes are made in the `ft-das` and `Metadata Update` FT.

`ft-das` starts the DAS Bootstrap and also generates a Root Metadata Update with DAS to be used by FT.

The FT  updates the Root Metadata without all required (threshold signatures).
While signing (using the CLI), it keeps sending artifacts to the TUF metadata, which we validate as consistent.