### PR TITLE
test: fix run-ft-signed metadata update inputs/select

### DIFF
--- a/tests/functional/scripts/run-ft-das.sh
+++ b/tests/functional/scripts/run-ft-das.sh
@@ -75,7 +75,7 @@ python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-metadata-update.py 
   "Please enter path to public key": "tests/files/key_storage/cb20fa1061dde8e6267e0bef0981766aaadae168e917030f7f26edc7a0bab9c2.pub",
   "Please enter key name": "online2",
   "[select] Select a key for signing (JanisJoplin/JimiHendrix)": "JanisJoplin",
-  "(Sign 1) Please enter path to public key": "tests/files/key_storage/JJ.ecdsa",
+  "(Sign 1) Please enter path to encrypted private key": "tests/files/key_storage/JJ.ecdsa",
   "(Sign 1) Please enter password": "hunter2",
   "[select] Select a key for signing (continue/JimiHendrix)": "continue"
 }'

--- a/tests/functional/scripts/run-ft-signed.sh
+++ b/tests/functional/scripts/run-ft-signed.sh
@@ -58,7 +58,6 @@ python ${UMBRELLA_PATH}/tests/functional/scripts/rstuf-admin-metadata-update.py 
   "[select] Select Online Key type": "Key PEM File",
   "Please enter path to public key": "tests/files/key_storage/cb20fa1061dde8e6267e0bef0981766aaadae168e917030f7f26edc7a0bab9c2.pub",
   "Please enter key name": "online2",
-  "[select] Info: Threshold 2 is met, more keys can be added (continue/add/remove)": "continue",
   "[select] Select a key for signing (JanisJoplin/JimiHendrix)": "JanisJoplin",
   "(root 1) Please enter path to encrypted private key": "tests/files/key_storage/JJ.ecdsa",
   "(root 1) Please enter password": "hunter2",


### PR DESCRIPTION
It fixes the `run-ft-signed.sh` metadata update inputs/select.

It was generating an update-metadata.json without signatures.