### PR TITLE
tests(ft): Add the FT using AWS KMS for online key 

### DIFF
--- a/ROADMAP.rst
+++ b/ROADMAP.rst
@@ -66,9 +66,9 @@ This release achieves the minimum valuable project for users.
 - [x] Deployment Design Document (`Issue #227 <https://github.com/repository-service-tuf/repository-service-tuf/issues/227>`_)
 - [x] Support to AWS S3 (Storage) (`Issue # <https://github.com/repository-service-tuf/repository-service-tuf/issues/24>`)
 - [x] Distributed asynchronous threshold signing (`Issue #327 <https://github.com/repository-service-tuf/repository-service-tuf/issues/327>`_)
-- [ ] Support to multiple Key Vaults for online Key during Ceremony/Metadata Update
-      - [ ] AWS KMS (`Issue #24 <https://github.com/repository-service-tuf/repository-service-tuf/issues/24>`_)
-      - [ ] Support of HashiCorp Vault (`Issue #509 <https://github.com/repository-service-tuf/repository-service-tuf/issues/509>`_)
+- [x] Support to multiple Key Vaults for online Key during Ceremony/Metadata Update
+      - [x] AWS KMS (`Issue #24 <https://github.com/repository-service-tuf/repository-service-tuf/issues/24>`_)
+      - [x] Support of HashiCorp Vault (`Issue #509 <https://github.com/repository-service-tuf/repository-service-tuf/issues/509>`_)
 - [ ] Support for Root Signing (Ceremony, Metadata Update and Sign)
       - [ ] HSM (Yubikey) (`Issue #351[cli] <https://github.com/repository-service-tuf/repository-service-tuf-cli/issues/351>`_)
       - [x] SigStore (`Issue #657[cli] <https://github.com/repository-service-tuf/repository-service-tuf-cli/issues/657>`_)


### PR DESCRIPTION
These changes add to the tests of the RSTUF CLI + Worker functionality to use SaaS/Vault as an online key signing.

This FT uses a CLI interface to add the AWS KMS Key when we run the Worker tests using localstack.

<!-- readthedocs-preview repository-service-tuf start -->
----
📚 Documentation preview 📚: https://repository-service-tuf--809.org.readthedocs.build/en/809/

<!-- readthedocs-preview repository-service-tuf end -->