### PR TITLE
test: fix ft for metadata update to use select key file

### DIFF
--- a/tests/functional/metadata/test_update.py
+++ b/tests/functional/metadata/test_update.py
@@ -151,9 +151,18 @@ def user_signs_the_metadata(http_request, task_id):
     assert count < 60, pytest.rstuf_thread.set()
 
     runner = CliRunner()
-    # role and key selection
+    # CLI role and key selection
     cli.admin.helpers._select = mock.MagicMock()
     cli.admin.helpers._select.side_effect = ["root", "JimiHendrix"]
+
+    # CLI key prompt select key file
+    cli.admin.helpers._prompt_key = mock.MagicMock()
+    cli.admin.helpers._prompt_key.side_effect = [
+        "tests/files/key_storage/JH.ed25519"
+    ]
+
+    # CLI input
+    input = ["hunter2"]
 
     # CLI settings
     folder_name = mkdtemp()
@@ -162,8 +171,6 @@ def user_signs_the_metadata(http_request, task_id):
     test_settings.SERVER = "http://repository-service-tuf-api"
     context = {"settings": test_settings, "config": setting_file}
 
-    # CLI input
-    input = ["tests/files/key_storage/JH.ed25519", "hunter2"]
     try:
         LOGGER.info("[METADATA UPDATE] Signing Metadata if available")
         runner.invoke(


### PR DESCRIPTION
fix test metadata update in the functional test to use the prompt key select file introduced to the CLI

This PR fixes the FT failing such as https://github.com/repository-service-tuf/repository-service-tuf-cli/actions/runs/12143120459/job/33859510693?pr=744

Tested locally
```log
pytest --exitfirst --splits 3 --group 3 --store-durations --durations-path=./.test_durations.3 --deselect=tests/functional/artifacts/test_performance.py tests -vvv --cucumberjson=test-report.json --durations=0 --html=test-report.html
============================================== test session starts ===============================================
platform linux -- Python 3.12.7, pytest-8.0.2, pluggy-1.5.0 -- /usr/local/bin/python3.12
cachedir: .pytest_cache
metadata: {'Python': '3.12.7', 'Platform': 'Linux-6.10.11-linuxkit-aarch64-with-glibc2.36', 'Packages': {'pytest': '8.0.2', 'pluggy': '1.5.0'}, 'Plugins': {'bdd-html': '0.1.14a0', 'metadata': '3.1.1', 'html': '4.1.1', 'bdd': '7.3.0', 'split': '0.10.0'}}
rootdir: /rstuf-runner/rstuf-umbrella
configfile: pytest.ini
plugins: bdd-html-0.1.14a0, metadata-3.1.1, html-4.1.1, bdd-7.3.0, split-0.10.0
collecting ... 

[pytest-split] Splitting tests with algorithm: duration_based_chunks
[pytest-split] Running group 3/3 (estimated duration: 40.69s)

collected 17 items / 13 deselected / 4 selected                                                                  

tests/functional/artifacts/test_remove_artifacts.py::test_removing_artifacts_that_does_exist_and_ignoring_the_rest[["file1.tar.gz", "a/file2.tar.gz"]-["foo", "bar"]] <- ../../usr/local/lib/python3.12/site-packages/pytest_bdd/scenario.py 
------------------------------------------------- live log call --------------------------------------------------
2024-12-04 07:49:41 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:49:41 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:49:44 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:49:44 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
PASSED                                                                                                     [ 25%]
tests/functional/bootstrap/test_bootstrap.py::test_bootstrap_using_rstuf_command_line_interface_cli <- ../../usr/local/lib/python3.12/site-packages/pytest_bdd/scenario.py PASSED [ 50%]
tests/functional/bootstrap/test_bootstrap.py::test_bootstrap_using_rstuf_cli_with_invalid_payload <- ../../usr/local/lib/python3.12/site-packages/pytest_bdd/scenario.py PASSED [ 75%]
tests/functional/metadata/test_update.py::test_sign_root_metadata_updated <- ../../usr/local/lib/python3.12/site-packages/pytest_bdd/scenario.py 
------------------------------------------------- live log call --------------------------------------------------
2024-12-04 07:49:46 [    INFO] Adding artifacts (test_update.py:26)
2024-12-04 07:49:46 [    INFO] Added task_id: 237852d53e6546f5b885703d85433155 (test_update.py:49)
2024-12-04 07:49:47 [    INFO] Adding artifacts (test_update.py:26)
2024-12-04 07:49:47 [    INFO] Added task_id: 6b3070db9963497ea2fab17339e37652 (test_update.py:49)
2024-12-04 07:49:48 [    INFO] [METADATA UPDATE] Submiting Root Metadata Update (test_update.py:94)
2024-12-04 07:49:48 [    INFO] [METADATA UPDATE] Metadata Updated by 0fe53a1a7e4a43189bd219fac314384f (test_update.py:120)
2024-12-04 07:49:48 [    INFO] [METADATA UPDATE] Task state: {'task_id': '0fe53a1a7e4a43189bd219fac314384f', 'state': 'STARTED', 'result': {}} (test_update.py:137)
2024-12-04 07:49:48 [    INFO] [METADATA UPDATE] Task state: {'task_id': '0fe53a1a7e4a43189bd219fac314384f', 'state': 'SUCCESS', 'result': {'message': 'Metadata Update Processed', 'status': True, 'task': 'metadata_update', 'last_update': '2024-12-04T07:49:48.237415Z', 'details': {'role': 'root', 'update': 'Root v2 is pending signatures'}}} (test_update.py:137)
2024-12-04 07:49:48 [    INFO] [METADATA UPDATE] Root available for signing (test_update.py:140)
2024-12-04 07:49:48 [    INFO] [METADATA UPDATE] Signing Metadata if available (test_update.py:174)
2024-12-04 07:49:48 [    INFO] No signature for keyid c6d8bf2e4f48b41ac2ce8eca21415ca8ef68c133b47fc33df03d4070a7e1e9cc (_payload.py:416)
2024-12-04 07:49:48 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:49:48 [    INFO] No signature for keyid c6d8bf2e4f48b41ac2ce8eca21415ca8ef68c133b47fc33df03d4070a7e1e9cc (_payload.py:416)
2024-12-04 07:49:48 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:49:49 [    INFO] Adding artifacts (test_update.py:26)
2024-12-04 07:49:49 [    INFO] Added task_id: ad25d25c4fcc4bdc81364a4077f1de4d (test_update.py:49)
2024-12-04 07:49:50 [    INFO] Adding artifacts (test_update.py:26)
2024-12-04 07:49:50 [    INFO] Added task_id: b146d8f72c394962b61038abd69998a6 (test_update.py:49)
2024-12-04 07:49:50 [    INFO] [METADATA UPDATE] Metadata Update available (2.root.json) (test_update.py:200)
2024-12-04 07:49:52 [    INFO] Adding artifacts (test_update.py:26)
2024-12-04 07:49:52 [    INFO] Added task_id: 96ca6f9869ff40d684e4336787a44c14 (test_update.py:49)
2024-12-04 07:49:53 [    INFO] Adding artifacts (test_update.py:26)
2024-12-04 07:49:53 [    INFO] Added task_id: ff8ae9d1686841e8899ee3ee617e16b7 (test_update.py:49)
2024-12-04 07:49:55 [    INFO] Adding artifacts (test_update.py:26)
2024-12-04 07:49:55 [    INFO] Added task_id: bfdf8f8277264c5bad54022c0bbe7b75 (test_update.py:49)
2024-12-04 07:49:55 [    INFO] Task 1/7 finshed! (test_update.py:223)
2024-12-04 07:49:56 [    INFO] Task 2/7 finshed! (test_update.py:223)
2024-12-04 07:49:56 [    INFO] Stop adding artifacts. Total requests: 7 (test_update.py:53)
2024-12-04 07:49:58 [    INFO] Task 3/7 finshed! (test_update.py:223)
2024-12-04 07:49:59 [    INFO] Task 4/7 finshed! (test_update.py:223)
2024-12-04 07:50:01 [    INFO] Task 5/7 finshed! (test_update.py:223)
2024-12-04 07:50:02 [    INFO] Task 6/7 finshed! (test_update.py:223)
2024-12-04 07:50:04 [    INFO] Task 7/7 finshed! (test_update.py:223)
2024-12-04 07:50:04 [    INFO] Verifying test/gifted_hypatia-0.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/priceless_poitras-1.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/dreamy_ritchie-2.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/inspiring_kowalevski-3.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/elated_sammet-4.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/tender_rhodes-5.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/admiring_gagarin-6.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/silly_newton-7.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/brave_chaplygin-8.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/great_albattani-9.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/amazing_austin-0.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/reverent_leakey-1.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/nifty_wiles-2.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/nifty_volhard-3.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/compassionate_hoover-4.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/loving_gauss-5.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/sweet_elbakyan-6.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/jolly_jemison-7.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/clever_ardinghelli-8.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/determined_austin-9.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/exciting_hopper-0.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/elegant_bouman-1.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/goofy_hawking-2.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/elastic_mclean-3.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/amazing_austin-4.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/suspicious_elgamal-5.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/nifty_kowalevski-6.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/elastic_cori-7.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/confident_pasteur-8.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/gracious_hermann-9.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/youthful_yalow-0.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/distracted_ritchie-1.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/busy_pascal-2.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/vigilant_gates-3.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/sleepy_tesla-4.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/relaxed_satoshi-5.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/suspicious_bose-6.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/interesting_visvesvaraya-7.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/intelligent_black-8.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/boring_babbage-9.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/goofy_chatelet-0.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/thirsty_brahmagupta-1.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/peaceful_payne-2.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/adoring_banzai-3.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/hardcore_wozniak-4.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/gallant_albattani-5.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/pedantic_diffie-6.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/quirky_mayer-7.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/cool_jackson-8.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/frosty_hugle-9.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/bold_jang-0.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/nervous_cori-1.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/confident_pare-2.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/epic_haibt-3.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/friendly_chebyshev-4.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/compassionate_driscoll-5.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/stupefied_ellis-6.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/great_clarke-7.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/flamboyant_aryabhata-8.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/amazing_pike-9.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/lucid_wilbur-0.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/competent_wozniak-1.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/tender_dhawan-2.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/gifted_panini-3.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/recursing_ganguly-4.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/stupefied_cray-5.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/nice_chatelet-6.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/silly_faraday-7.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/adoring_kapitsa-8.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] Verifying test/jolly_satoshi-9.tar.gz (test_update.py:230)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
2024-12-04 07:50:04 [    INFO] No signature for keyid 2f685fa7546f1856b123223ab086b3def14c89d24eef18f49c32508c2f60e241 (_payload.py:416)
PASSED                                                                                                     [100%]

[pytest-split] Stored test durations in ./.test_durations.3


================================================ warnings summary ================================================
../../usr/local/lib/python3.12/site-packages/dynaconf/contrib/flask_dynaconf.py:15
  /usr/local/lib/python3.12/site-packages/dynaconf/contrib/flask_dynaconf.py:15: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

../../usr/local/lib/python3.12/site-packages/pkg_resources/__init__.py:3154
../../usr/local/lib/python3.12/site-packages/pkg_resources/__init__.py:3154
  /usr/local/lib/python3.12/site-packages/pkg_resources/__init__.py:3154: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('sphinxcontrib')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

tests/functional/artifacts/test_remove_artifacts.py::test_removing_artifacts_that_does_exist_and_ignoring_the_rest[["file1.tar.gz", "a/file2.tar.gz"]-["foo", "bar"]]
tests/functional/artifacts/test_remove_artifacts.py::test_removing_artifacts_that_does_exist_and_ignoring_the_rest[["file1.tar.gz", "a/file2.tar.gz"]-["foo", "bar"]]
tests/functional/artifacts/test_remove_artifacts.py::test_removing_artifacts_that_does_exist_and_ignoring_the_rest[["file1.tar.gz", "a/file2.tar.gz"]-["foo", "bar"]]
tests/functional/bootstrap/test_bootstrap.py::test_bootstrap_using_rstuf_command_line_interface_cli
tests/functional/bootstrap/test_bootstrap.py::test_bootstrap_using_rstuf_cli_with_invalid_payload
tests/functional/metadata/test_update.py::test_sign_root_metadata_updated
tests/functional/metadata/test_update.py::test_sign_root_metadata_updated
tests/functional/metadata/test_update.py::test_sign_root_metadata_updated
  /usr/local/lib/python3.12/site-packages/pytest_bdd/compat.py:51: PytestDeprecationWarning: A private pytest class or function was used.
    fd = FixtureDef(

tests/functional/artifacts/test_remove_artifacts.py: 3 warnings
tests/functional/bootstrap/test_bootstrap.py: 6 warnings
tests/functional/metadata/test_update.py: 3 warnings
  /usr/local/lib/python3.12/site-packages/pytest_html/basereport.py:356: DeprecationWarning: The 'py' module is deprecated and support will be removed in a future release.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
----------------------- generated json file: /rstuf-runner/rstuf-umbrella/test-report.json -----------------------
=============================================== slowest durations ================================================
18.87s call     tests/functional/metadata/test_update.py::test_sign_root_metadata_updated
6.08s call     tests/functional/artifacts/test_remove_artifacts.py::test_removing_artifacts_that_does_exist_and_ignoring_the_rest[["file1.tar.gz", "a/file2.tar.gz"]-["foo", "bar"]]
0.69s call     tests/functional/bootstrap/test_bootstrap.py::test_bootstrap_using_rstuf_cli_with_invalid_payload
0.68s call     tests/functional/bootstrap/test_bootstrap.py::test_bootstrap_using_rstuf_command_line_interface_cli
0.00s teardown tests/functional/artifacts/test_remove_artifacts.py::test_removing_artifacts_that_does_exist_and_ignoring_the_rest[["file1.tar.gz", "a/file2.tar.gz"]-["foo", "bar"]]
0.00s setup    tests/functional/bootstrap/test_bootstrap.py::test_bootstrap_using_rstuf_command_line_interface_cli
0.00s setup    tests/functional/artifacts/test_remove_artifacts.py::test_removing_artifacts_that_does_exist_and_ignoring_the_rest[["file1.tar.gz", "a/file2.tar.gz"]-["foo", "bar"]]
0.00s setup    tests/functional/metadata/test_update.py::test_sign_root_metadata_updated
0.00s teardown tests/functional/metadata/test_update.py::test_sign_root_metadata_updated
0.00s setup    tests/functional/bootstrap/test_bootstrap.py::test_bootstrap_using_rstuf_cli_with_invalid_payload
0.00s teardown tests/functional/bootstrap/test_bootstrap.py::test_bootstrap_using_rstuf_cli_with_invalid_payload
0.00s teardown tests/functional/bootstrap/test_bootstrap.py::test_bootstrap_using_rstuf_command_line_interface_cli
------------------ Generated html report: file:///rstuf-runner/rstuf-umbrella/test-report.html -------------------
================================= 4 passed, 13 deselected, 23 warnings in 26.68s =================================
make: Leaving directory '/rstuf-runner/rstuf-umbrella'
```