### PR TITLE
Upgraded docker containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ volumes:
 
 services:
   postgres:
-    image: postgres:15.1
+    image: postgres:17.5-alpine3.21
     ports:
       - "5433:5432"
     environment:
@@ -32,7 +32,7 @@ services:
         condition: service_healthy
 
   web:
-    image: python:3.10-slim-buster
+    image: python:3.13-slim
     command: python -m http.server -d /var/opt/repository-service-tuf/storage 8080
     volumes:
       - repository-service-tuf-storage:/var/opt/repository-service-tuf/storage
@@ -40,7 +40,7 @@ services:
       - "8080:8080"
 
   redis:
-    image: redis:4.0
+    image: redis:8.0.0-alpine3.21
     volumes:
       - repository-service-tuf-redis-data:/data
     ports:


### PR DESCRIPTION
Upgrades the docker containers from:

- Postress 15.1 to 17.5

Both have the same vulnerability scores and none of the other images have a lower vulnerability score.

- python 3.10 to 3.13

3.13 image has no identified vulnerabilities until now

- redis 4.0 to 8.0 

The 4.0 image had vulnerabilities while the 8.0 doesn't have any vulnerabilities until now.