### PR TITLE
Updated docker images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ volumes:
 
 services:
   postgres:
-    image: postgres:15.1
+    image: postgres:17.5-alpine3.21
     ports:
       - "5433:5432"
     environment:
@@ -32,7 +32,7 @@ services:
         condition: service_healthy
 
   web:
-    image: python:3.10-slim-buster
+    image: python:3.13-slim
     command: python -m http.server -d /var/opt/repository-service-tuf/storage 8080
     volumes:
       - repository-service-tuf-storage:/var/opt/repository-service-tuf/storage
@@ -40,7 +40,7 @@ services:
       - "8080:8080"
 
   redis:
-    image: redis:4.0
+    image: redis:8.0.0-alpine3.21
     volumes:
       - repository-service-tuf-redis-data:/data
     ports:

--- a/docs/source/guide/deployment/guide/docker-compose.yml
+++ b/docs/source/guide/deployment/guide/docker-compose.yml
@@ -9,7 +9,7 @@ volumes:
 
 services:
   redis:
-    image: redis:4.0
+    image: redis:8.0.0-alpine3.21
     volumes:
       - rstuf-redis-data:/data
     healthcheck:
@@ -18,7 +18,7 @@ services:
     tty: true
 
   postgres:
-    image: postgres:15.1
+    image: postgres:17.5-alpine3.21
     ports:
       - "5433:5432"
     # DO NOT USE IT IN PRODUCTION. Check the Postgres best practices
@@ -52,7 +52,7 @@ services:
     tty: true
 
   web-server:
-    image: python:3.10-slim-buster
+    image: python:3.13-slim
     command: python -m http.server -d /www 8080
     volumes:
       - rstuf-storage:/www

--- a/docs/source/guide/deployment/guide/k8s/deployment.yml
+++ b/docs/source/guide/deployment/guide/k8s/deployment.yml
@@ -22,7 +22,7 @@ spec:
         io.kompose.service: redis
     spec:
       containers:
-        - image: redis:4.0
+        - image: redis:8.0.0-alpine3.21
           livenessProbe:
             exec:
               command:
@@ -71,7 +71,7 @@ spec:
                   key: password
             - name: PGDATA
               value: /var/lib/postgresql/data/rstuf
-          image: postgres:15.1
+          image: postgres:17.5-alpine3.21
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
solves #853

Upgrades the docker containers from:
    
    Postress 15.1 to 17.5
    Both have the same vulnerability scores and none of the other images have a lower vulnerability score.
    
    python 3.10 to 3.13
    3.13 image has no identified vulnerabilities until now
    
    redis 4.0 to 8.0
    The 4.0 image had vulnerabilities while the 8.0 doesn't have any vulnerabilities until now.
    
Updated the docs to reflect the above changes

<!-- readthedocs-preview repository-service-tuf start -->
----
📚 Documentation preview 📚: https://repository-service-tuf--871.org.readthedocs.build/en/871/

<!-- readthedocs-preview repository-service-tuf end -->