### PR TITLE
docs: Update hosts file configuration in quick-start guide

### DIFF
--- a/docs/source/guide/deployment/guide/quick-start.rst
+++ b/docs/source/guide/deployment/guide/quick-start.rst
@@ -80,7 +80,7 @@ Add to .local domain the RSTUF API and Localstack services
 
 .. code:: shell
 
-    ❯ echo "$(minikube ip) rstuf.local localstack.local" | sudo tee -a /etc/hosts
+    ❯ echo "127.0.0.1 rstuf.local localstack.local" | sudo tee -a /etc/hosts
 
 
 Start the minikube tunnel:


### PR DESCRIPTION
## Description
Updated the hosts file configuration in the quick-start guide to use `127.0.0.1` instead of `$(minikube ip)`.

## Changes
- Modified the hosts file entry command to use `127.0.0.1` instead of `$(minikube ip)`
- This change ensures proper routing through the Minikube tunnel for ingress resources

When using Minikube with the Docker driver, the services are exposed through the `minikube tunnel` command, which makes them available on localhost (127.0.0.1). The `minikube ip` is only accessible in the docker network and would bypass the tunnel which prevents proper access to the ingress resources.

## Testing
- Verified that both `rstuf.local` and `localstack.local` are accessible after applying the changes

CC: @kairoaraujo 

<!-- readthedocs-preview repository-service-tuf start -->
----
📚 Documentation preview 📚: https://repository-service-tuf--874.org.readthedocs.build/en/874/

<!-- readthedocs-preview repository-service-tuf end -->