### PR TITLE
Removed the use of status field in result object from functional tests

### DIFF
--- a/tests/functional/artifacts/test_performance.py
+++ b/tests/functional/artifacts/test_performance.py
@@ -97,11 +97,9 @@ def get_tasks(multiple_requests, http_request, timeout):
 
             data = response.json()["data"]
             state = data.get("state", None)
-            if state == "SUCCESS":
-                result = data.get("result", {})
-                if result.get("status", False) is True:
-                    tasks_result.append(task)
-                    tasks.remove(task)
+            if state == "ERRORED":
+                tasks_result.append(task)
+                tasks.remove(task)
 
     return tasks_result
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -94,12 +94,9 @@ def task_completed_within_threshold():
             )
             assert response.status_code == 200, response.text
             task_response_json = response.json()
-            # "result" is missing when the task is still "PENDING"
-            result = task_response_json["data"].get("result")
-            if result is not None:
-                # "status" is missing when the task is in its earliest stage
-                if result.get("status") is True:
-                    break
+            state = task_response_json["data"].get("state")
+            if state == "SUCCESS":
+                break
 
         perfomance_fail = os.getenv("PERFORMANCE", "true").lower() == "true"
         if (


### PR DESCRIPTION
Fixes #622

The following PR simplifies the functional tests by removing the check for result[status] in the tests. Since if (state == "SUCCESS" and status == "false") => state = "ERRORED", the state variable can directly be leveraged to simplify the tests.
