### PR TITLE
docs: implement versioning guide for RSTUF documentation

### DIFF
--- a/docs/source/devel/documentation.rst
+++ b/docs/source/devel/documentation.rst
@@ -74,8 +74,19 @@ documentation using the Makefile (``make docs``)
 For each component, the ``make docs`` should also be available.
 
 
-Releasing new Documentation Version
-===================================
+Versioning Documentation
+=======================
+
+The RSTUF documentation follows the same versioning scheme as the software components (X.Y.Z). When a new version of RSTUF is released, a corresponding version of the documentation is created.
+
+To create a new documentation version:
+
+1. Ensure all documentation changes for the release are merged to the main branch
+2. Tag the repository with the new version (e.g., v1.2.3)
+3. The CI/CD pipeline will build the documentation and create a new version on ReadTheDocs
+4. Update the version history in the :ref:`guide/general/versioning:Documentation Versioning` guide
+
+This ensures users can access documentation specific to their RSTUF version.
 
 In the
 `umbrella repository <https://github.com/repository-service-tuf/repository-service-tuf>`_

--- a/docs/source/guide/general/versioning.rst
+++ b/docs/source/guide/general/versioning.rst
@@ -1,0 +1,70 @@
+#######################
+Documentation Versioning
+#######################
+
+RSTUF Documentation Versioning
+==============================
+
+The Repository Service for TUF (RSTUF) documentation is versioned to ensure users can access the correct documentation for the specific version of RSTUF they are using.
+
+How Versioning Works
+-------------------
+
+RSTUF documentation follows the same versioning scheme as the software components: ``X.Y.Z`` where:
+
+- ``X`` is the major version (incompatible changes)
+- ``Y`` is the minor version (new features)
+- ``Z`` is the micro version (bugfixes)
+
+Each released version of the documentation corresponds to a specific release of the RSTUF components.
+
+Accessing Versioned Documentation
+--------------------------------
+
+You can access specific versions of the documentation in several ways:
+
+1. **Latest Documentation**: The default documentation at https://repository-service-tuf.readthedocs.io/en/latest/ always shows the most recent release.
+
+2. **Specific Version**: To access documentation for a specific version, use the version selector dropdown in the bottom-left corner of the ReadTheDocs interface, or use URLs in the format: https://repository-service-tuf.readthedocs.io/en/vX.Y.Z/
+
+3. **Development Version**: The documentation for the current development version (not yet released) is available at https://repository-service-tuf.readthedocs.io/en/develop/
+
+Version History
+--------------
+
+Below is a list of major documentation versions and the significant changes they contain:
+
+.. list-table:: Documentation Version History
+   :header-rows: 1
+   :widths: 15 15 70
+
+   * - Version
+     - Release Date
+     - Major Changes
+   * - 1.0.0
+     - YYYY-MM-DD
+     - Initial stable release
+   * - 0.9.0
+     - YYYY-MM-DD
+     - Beta release with complete feature set
+   * - 0.8.0
+     - YYYY-MM-DD
+     - Alpha release with core functionality
+
+Component-Specific Documentation
+-------------------------------
+
+Each RSTUF component (API, Worker, CLI) maintains its own versioned documentation as well. The umbrella documentation aggregates these component-specific docs into a comprehensive guide.
+
+When a component is updated, its documentation is updated accordingly, and these changes are reflected in the next release of the umbrella documentation.
+
+Documentation Feedback
+--------------------
+
+If you find any issues with the documentation or have suggestions for improvement, please:
+
+1. Open an issue in the `RSTUF repository <https://github.com/repository-service-tuf/repository-service-tuf/issues>`_
+2. Specify which version of the documentation you're referring to
+3. Provide details about the issue or suggestion
+
+Your feedback helps us improve the documentation for all users.

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -23,5 +23,20 @@ Components documentation
         repository-service-tuf-cli/index
 
 .. toctree::
-   :maxdepth: 5
-   :caption: Contents:
+   :maxdepth: 2
+   :caption: General
+
+   general/introduction
+   general/usage
+   general/client
+   general/versioning
+
+Components documentation
+########################
+
+    .. toctree::
+        :maxdepth: 5
+
+        repository-service-tuf-api/index
+        repository-service-tuf-worker/index
+        repository-service-tuf-cli/index

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -166,3 +166,16 @@ Documentation List
 
 .. [#] `Wikipedia <https://en.wikipedia.org/wiki/The_Update_Framework>`_
 .. [#] Warehouse_
+
+
+Documentation Versions
+=====================
+
+This documentation is versioned to match RSTUF software releases. You are currently viewing the **latest** version.
+
+To access documentation for a specific version:
+
+* Use the version selector in the bottom-left corner of this page
+* Or visit: https://repository-service-tuf.readthedocs.io/en/vX.Y.Z/
+
+For more information, see the :ref:`guide/general/versioning:Documentation Versioning` guide.


### PR DESCRIPTION
## Description
This PR implements a versioning guide for RSTUF documentation as requested in issue #324.

The implementation:
- Creates a new versioning.rst file explaining how documentation versioning works
- Updates the guide/index.rst to include the new versioning guide in navigation
- Explains how users can access different versions of the documentation
- Provides information about the relationship between software versions and docs

## Related Issue
Fixes #324

## Type of Change
- [x] Documentation update

## Testing
- [x] Documentation builds successfully
- [x] All links work correctly