### PR TITLE
Fixed indentation error in functional.yml

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -18,11 +18,11 @@ on:
           default: "latest"
           type: string
           required: False
-      docker_compose:
-        description: "Docker Compose File"
-        default: "docker-compose.yml"
-        type: string
-        required: False
+        docker_compose:
+          description: "Docker Compose File"
+          default: "docker-compose.yml"
+          type: string
+          required: False
 
   workflow_call:
     inputs:


### PR DESCRIPTION
There was a simple indentation error in functional.yml file in the github workflows:

Original:
```yml
...
on:
  workflow_dispatch:
      inputs:
        api_version:
          ...
        worker_version:
          ...
        cli_version:
          ...
      docker_compose:
        description: "Docker Compose File"
        default: "docker-compose.yml"
        type: string
        required: False
```

Modified:
```yml
on:
  workflow_dispatch:
      inputs:
        api_version:
          ...
        worker_version:
          ...
        cli_version:
          ...
        docker_compose:
          description: "Docker Compose File"
          default: "docker-compose.yml"
          type: string
          required: False
```