### PR TITLE
fix: remove task when in success state

### DIFF
--- a/tests/functional/artifacts/test_performance.py
+++ b/tests/functional/artifacts/test_performance.py
@@ -97,7 +97,7 @@ def get_tasks(multiple_requests, http_request, timeout):
 
             data = response.json()["data"]
             state = data.get("state", None)
-            if state == "ERRORED":
+            if state in ("SUCCESS", "ERRORED"):
                 tasks_result.append(task)
                 tasks.remove(task)
 


### PR DESCRIPTION
Previously a [change was made](https://github.com/repository-service-tuf/repository-service-tuf/pull/877/files) in the performance test file to include a check for the `ERRORED` state, but the check for `SUCCESS` endedup being removed as well, causing the tasks not to be removed when in `SUCCESS` state in the `get_tasks` function and making them stay in the loop for longer. 
For some cases this resulted in the tests failing when running the preformance tests.    