### PR TITLE
Add default value to PYTEST_GROUP

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -326,11 +326,26 @@ Now ``pre-commit`` will run automatically on ``git commit``.
 
 Running tests
 ^^^^^^^^^^^^^
-To run the tests, use the following command:
+To run the Functional Tests:
+    
+1. Make sure you have a development environment running (``make run-dev``).    
+2. Use one of the following commands:
 
 .. code:: shell
 
-    $ make test
+    $ make ft-das
+    $ make ft-signed
+
+The following parameters can be passed to the commands:
+
+- ``CLI_VERSION``: to use a specific version of the CLI (``make ft-das CLI_VERSION=v0.8.0b1``)
+- ``PYTEST_GROUP``: to run a specific group of tests (``make ft-das PYTEST_GROUP=1``)
+- ``SLOW``: to run the performance tests (``make ft-das SLOW=1``)
+
+.. code:: shell
+
+    $ make ft-das CLI_VERSION=v0.8.0b1 PYTEST_GROUP=1 SLOW=yes
+    $ make ft-signed CLI_VERSION=latest PYTEST_GROUP=1 SLOW=yes
 
 
 How to add new dependency

--- a/tests/functional/scripts/run-ft-das.sh
+++ b/tests/functional/scripts/run-ft-das.sh
@@ -128,4 +128,4 @@ if [[ ${UMBRELLA_PATH} != "." ]]; then
     cp ceremony-payload.json ${UMBRELLA_PATH}/
 fi
 
-make -C ${UMBRELLA_PATH}/ functional-tests-exitfirst PYTEST_GROUP=${PYTEST_GROUP} SLOW=${SLOW}
+make -C ${UMBRELLA_PATH}/ functional-tests-exitfirst PYTEST_GROUP=${PYTEST_GROUP:-1} SLOW=${SLOW}

--- a/tests/functional/scripts/run-ft-signed.sh
+++ b/tests/functional/scripts/run-ft-signed.sh
@@ -78,4 +78,4 @@ if [[ ${UMBRELLA_PATH} != "." ]]; then
     cp ceremony-payload.json ${UMBRELLA_PATH}/
 fi
 
-make -C ${UMBRELLA_PATH}/ functional-tests-exitfirst PYTEST_GROUP=${PYTEST_GROUP} SLOW=${SLOW}
+make -C ${UMBRELLA_PATH}/ functional-tests-exitfirst PYTEST_GROUP=${PYTEST_GROUP:-1} SLOW=${SLOW}


### PR DESCRIPTION
When running the functional tests without any parameters (`ft-das`, `ft-signed`, `ft-ft-das-local`, `ft-signed-local`) we get an error: `pytest: error: argument --group: expected one argument` because the PYTEST_GROUP is empty. 

This PR adds a default value to PYTEST_GROUP making it possible to run this commands without error. 

Also updates the documentation.  