### PR TITLE
feat: add SECURITY_INSIGHTS.yml following OpenSSF spec

### DIFF
--- a/SECURITY_INSIGHTS.yml
+++ b/SECURITY_INSIGHTS.yml
@@ -1,79 +1,47 @@
 header:
   schema-version: 2.1.0
-  last-updated: "2025-06-03" # Update after review
-  last-reviewed: "2025-06-03" # Update after review
-  url: https://github.com/repository-service-tuf/repository-service-tuf
+  last-updated: "2026-03-26"
+  last-reviewed: "2026-03-26"
+  project-url: https://github.com/repository-service-tuf/repository-service-tuf
 
 project:
   name: Repository Service for TUF (RSTUF)
-  administrators:
-    - name: Kairo de Araujo
-      email: kairo.araujo@eclipse-foundation.org
-      social: https://github.com/kairoaraujo
-      primary: true
-    - name: Martin Vrachev
-      email: martin.vrachev@gmail.com
-      social: https://github.com/MVrachev
-    - name: Radoslav Dimitrov
-      email: radoslav@stacklok.com
-      social: https://github.com/rdimitrov
-    - name: Lukas Pühringer
-      email: lukas.puehringer@nyu.edu
-      social: https://github.com/lukpueh
-    - name: Konstantinos Papadopoulos
-      email: konpap1996@yahoo.com
-      social: https://github.com/KAUTH
   repositories:
-    - name: Repository Service for TUF (RSTUF)
+    - name: RSTUF Umbrella
       url: https://github.com/repository-service-tuf/repository-service-tuf
-      comment: |
-        Is the Umbrella Repository Service for TUF
-    - name: Repository Service for TUF Command Line Interface (CLI)
-      url: https://github.com/repository-service-tuf/repository-service-tuf-cli
-      comment: |
-        The Repository Service for TUF Command Line Interface (CLI) is a CLI Python application to manage the Repository Service for TUF.
-    - name: Repository Service for TUF API
+    - name: RSTUF API
       url: https://github.com/repository-service-tuf/repository-service-tuf-api
-      comment: |
-        Repository Service for TUF API Service
-    - name: Repository Service for TUF Worker
+    - name: RSTUF CLI
+      url: https://github.com/repository-service-tuf/repository-service-tuf-cli
+    - name: RSTUF Worker
       url: https://github.com/repository-service-tuf/repository-service-tuf-worker
-      comment: |
-        Repository Service for TUF Worker
-  vulnerability-reporting:
-    reports-accepted: true
-    bug-bounty-available: false
 
 repository:
   url: https://github.com/repository-service-tuf/repository-service-tuf
   status: active
-  accepts-change-request: true
-  accepts-automated-change-request: true
-  core-team:
-    - name: Kairo de Araujo
-      email: kdearaujo@vmware.com
-      social: https://github.com/kairoaraujo
-      primary: true
-    - name: Martin Vrachev
-      email: mvrachev@vmware.com
-      social: https://github.com/MVrachev
-    - name: Radoslav Dimitrov
-      email: dimitrovr@vmware.com
-      social: https://github.com/rdimitrov
-    - name: Lukas Pühringer
-      email: lukas.puehringer@nyu.edu
-      social: https://github.com/lukpueh
-    - name: Konstantinos Papadopoulos
-      email: konpap1996@yahoo.com
-      social: https://github.com/KAUTH
-  license:
-    url: https://github.com/repository-service-tuf/repository-service-tuf/blob/main/LICENSE
-    expression: MIT
-  security:
-    assessments:
-      third-party:
-        - evidence: https://repository-service-tuf.readthedocs.io/en/stable/blog/posts/rstuf-security-audit-for-1.0.0.html
-          date: "2025-02-14"
-          comment: |
-            Security assessment conducted by X41 D-Sec GmbH. The assessment focused on the design, implementation, and deployment of RSTUF services and tools. 
-            The X41 team identified a set of findings ranging from low to high severity — importantly, no critical vulnerabilities were discovered.
+
+project-lifecycle:
+  status: active
+  core-maintainers:
+    - https://github.com/kairoaraujo
+    - https://github.com/MVrachev
+    - https://github.com/rdimitrov
+    - https://github.com/lukpueh
+    - https://github.com/KAUTH
+
+contribution-policy:
+  accepts-pull-requests: true
+  contributing-policy: https://github.com/repository-service-tuf/repository-service-tuf/blob/main/CONTRIBUTING.rst
+  code-of-conduct: https://github.com/repository-service-tuf/repository-service-tuf/blob/main/CODE_OF_CONDUCT.rst
+
+documentation:
+  security-policy: https://github.com/repository-service-tuf/repository-service-tuf/blob/main/SECURITY.md
+  project-members: https://github.com/repository-service-tuf/repository-service-tuf/blob/main/MAINTAINERS.rst
+
+security-artifacts:
+  third-party-assessments:
+    - evidence: https://repository-service-tuf.readthedocs.io/en/stable/blog/posts/rstuf-security-audit-for-1.0.0.html
+      date: "2025-02-14"
+      comment: |
+        Security assessment conducted by X41 D-Sec GmbH. The assessment focused on the design,
+        implementation, and deployment of RSTUF services and tools.


### PR DESCRIPTION
Adds SECURITY_INSIGHTS.yml to the repository following the OpenSSF Security Insights specification.

Includes project metadata, lifecycle information, and references to contributing and security policies. The structure is kept minimal and aligned for potential reuse across other RSTUF components.

Resolves #789