### PR TITLE
test: use retry mechanism instead of waiting for root metadata

### DIFF
--- a/tests/features/metadata/update.feature
+++ b/tests/features/metadata/update.feature
@@ -9,5 +9,4 @@ Feature: Metadata Update
         When the RSTUF Admin User sends a metadata update
         Then the API requester should get status code '202' with 'task_id'
         Then the Admin User runs the CLI to sign the metadata
-        Then the '2.root.json' will be available in the TUF Metadata
         Then the user downloads will not have inconsistency during this process

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,8 +1,10 @@
+import logging
 import os
 import re
 import shutil
 import subprocess
 import tempfile
+import time
 from datetime import datetime, timezone
 from typing import List
 
@@ -70,8 +72,21 @@ def get_target_info():
             metadata_base_url=metadata_base_url,
             config=UpdaterConfig(prefix_targets_with_hash=False),
         )
-        updater.refresh()
-        return updater.get_targetinfo(target_path)
+
+        for i in range(60):
+            try:
+                updater.refresh()
+                target_info = updater.get_targetinfo(target_path)
+                if target_info:
+                    return target_info
+            except Exception as e:
+                logging.info(
+                    f"Target info fetching failed: {e}. Retrying {i+1}/60..."
+                )
+                pass
+            time.sleep(2)
+
+        return None
 
     return _run_get_target_info
 

--- a/tests/functional/metadata/test_update.py
+++ b/tests/functional/metadata/test_update.py
@@ -192,35 +192,14 @@ def user_signs_the_metadata(http_request, task_id):
             pass
 
 
-@then("the '2.root.json' will be available in the TUF Metadata")
-def root_metadata_2_root_is_available(http_request):
-    # double check if the new version is available in the metadata storage
-    metadata_base_url = os.getenv("METADATA_BASE_URL") or "http://web:8080"
-    count = 0
-    while count < 60:
-        response = http_request(
-            "GET",
-            host=metadata_base_url,
-        )
-        if "2.root.json" in response.text:
-            LOGGER.info(
-                "[METADATA UPDATE] Metadata Update available (2.root.json)"
-            )
-            # wait add artifacts continue 2 seconds after metadata update
-            time.sleep(5)
-            pytest.rstuf_thread.set()
-            break
-        else:
-            count += 1
-            time.sleep(0.5)
-
-    assert count < 60, pytest.rstuf_thread.set()
-
-
 @then("the user downloads will not have inconsistency during this process")
 def verify_artifacts_consistency(
     get_target_info, http_request, task_completed_within_threshold
 ):
+    # wait add artifacts continue 5 seconds after metadata update starts
+    time.sleep(5)
+    pytest.rstuf_thread.set()
+
     try:
         # wait all artifact tasks to be complete and check the consistency
         count = 1


### PR DESCRIPTION
Fixes #688

## Description

Improves the functional test to not wait for the new root metadata (`2.root.json`) before verifying artifact consistency. Instead, the test now relies on a retry mechanism in the TUF client, better simulating real-world behavior where clients don't know when a root metadata update occurs.

## How it works now

Previously the test waited for `2.root.json` to appear before checking artifact consistency. Now `get_target_info` bootstraps from `1.root.json` and lets `Updater.refresh()` naturally discover root rotations — retrying on failure — just like a real TUF client would.
