### PR TITLE
docs: add security advisory for Docker deployment

### DIFF
--- a/docs/source/guide/deployment/guide/docker.rst
+++ b/docs/source/guide/deployment/guide/docker.rst
@@ -12,6 +12,18 @@ This deployment uses Docker Engine and Docker Compose yaml file to deploy RSTUF.
 
   * This deployment does not use secrets for sensitive credentials.
 
+  * This deployment does not isolate services into separate Docker networks.
+    All containers share a single default network, meaning a compromised
+    public-facing container (e.g., the web server) could access internal
+    services such as Redis or PostgreSQL. For production environments, consider
+    using network segmentation to restrict inter-container communication, or use
+    the :ref:`guide/deployment/guide/helm:Helm` deployment.
+
+  * The PostgreSQL example uses a default password (``secret``). This is
+    acceptable for local development and testing only. For any production or
+    publicly accessible deployment, use strong, unique credentials and manage
+    them through secrets.
+
 
 .. note::
   See the complete :ref:`guide/deployment/planning/deployment:Deployment Configuration`


### PR DESCRIPTION
## Description

This PR addresses issue #857 (RSTUF-CR-25-109) by adding security advisory notes to the Docker deployment documentation (`docker.rst`). 
As discussed in the issue, since the Docker Compose setup is primarily intended for development and testing, we are addressing the audit findings via documentation rather than modifying the development compose files.

The advisory warns users about:
- The lack of network isolation between containers, explaining that a compromised public-facing container could access internal services
- The insecure default PostgreSQL password being suitable only for local development
- A strong recommendation to use the Helm deployment or implement network segmentation for any production usage

Fixes #857


<!-- readthedocs-preview repository-service-tuf start -->
----
📚 Documentation preview 📚: https://repository-service-tuf--946.org.readthedocs.build/en/946/

<!-- readthedocs-preview repository-service-tuf end -->