### PR TITLE
security: run services as non-root user (RSTUF-CR-25-111)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,10 +20,13 @@ services:
 
   repository-service-tuf-api:
     image: ghcr.io/repository-service-tuf/repository-service-tuf-api:${API_VERSION}
+    user: "1000:1000"
+    security_opt:
+      - no-new-privileges:true
     volumes:
       - repository-service-tuf-api-data:/data
     ports:
-      - 80:80
+      - 80:8080
     environment:
       - RSTUF_BROKER_SERVER=redis://redis
       - RSTUF_REDIS_SERVER=redis://redis
@@ -51,6 +54,9 @@ services:
 
   repository-service-tuf-worker:
     image: ghcr.io/repository-service-tuf/repository-service-tuf-worker:${WORKER_VERSION}
+    user: "1000:1000"
+    security_opt:
+      - no-new-privileges:true
     environment:
       - RSTUF_STORAGE_BACKEND=LocalStorage
       - RSTUF_LOCAL_STORAGE_BACKEND_PATH=/var/opt/repository-service-tuf/storage

--- a/docs/source/guide/deployment/guide/kubernetes.rst
+++ b/docs/source/guide/deployment/guide/kubernetes.rst
@@ -237,7 +237,8 @@ rstuf-api deployment
 * RSTUF API will use environment variables ``RSTUF_BROKER_SERVER`` and
   ``RSTUF_REDIS_SERVER`` as :ref:`guide/deployment/guide/kubernetes:redis deployment`
   address (``redis://redis``).
-* RSTUF API container will use port 80 to serve the API (internally)
+* RSTUF API container will use port 8080 to serve the API (internally)
+* Containers run as a non-root user (UID 1000) for security hardening.
 
 rstuf-worker deployment
 =======================

--- a/docs/source/guide/deployment/guide/quick-start.rst
+++ b/docs/source/guide/deployment/guide/quick-start.rst
@@ -94,7 +94,7 @@ Start the minikube tunnel:
 
     ❗  The service/ingress rstuf-localstack requires privileged ports to be exposed: [80 443]
     🔑  sudo permission will be asked for it.
-    ❗  The service/ingress rstuf-rstuf-api requires privileged ports to be exposed: [80 443]
+    ❗  The service/ingress rstuf-rstuf-api requires ports to be exposed: [8080 8443]
     🏃  Starting tunnel for service rstuf-localstack.
     🔑  sudo permission will be asked for it.
     🏃  Starting tunnel for service rstuf-rstuf-api.
@@ -103,7 +103,7 @@ Start the minikube tunnel:
 
 .. note::
 
-   - RSTUF API is available at http://rstuf.local
+   - RSTUF API is available at http://rstuf.local:8080
    - TUF Metadata is available at http://localstack.local/tuf-metadata
 
 You can go through the RSTUF setup ceremony and bootstrap,

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -32,7 +32,7 @@ def http_request():
     def _run_requests(
         method,
         headers=None,
-        host="http://repository-service-tuf-api",
+        host="http://repository-service-tuf-api:8080",
         url="/",
         data=None,
         json=None,

--- a/tests/functional/metadata/test_update.py
+++ b/tests/functional/metadata/test_update.py
@@ -172,7 +172,7 @@ def user_signs_the_metadata(http_request, task_id):
     folder_name = mkdtemp()
     setting_file = os.path.join(folder_name, ".rstuf.yml")
     test_settings = Dynaconf()
-    test_settings.SERVER = "http://repository-service-tuf-api"
+    test_settings.SERVER = "http://repository-service-tuf-api:8080"
     test_settings.HEADERS = None
     context = {"settings": test_settings, "config": setting_file}
 

--- a/tests/functional/scripts/rstuf-admin-ceremony.py
+++ b/tests/functional/scripts/rstuf-admin-ceremony.py
@@ -12,7 +12,7 @@ def _run(input, selection, input_file):
     folder_name = mkdtemp()
     setting_file = os.path.join(folder_name, ".rstuf.yml")
     test_settings = Dynaconf()
-    test_settings.SERVER = "http://repository-service-tuf-api"
+    test_settings.SERVER = "http://repository-service-tuf-api:8080"
     test_settings.HEADERS = None
     context = {"settings": test_settings, "config": setting_file}
 

--- a/tests/functional/scripts/rstuf-admin-metadata-sign.py
+++ b/tests/functional/scripts/rstuf-admin-metadata-sign.py
@@ -12,7 +12,7 @@ def _run(input, selection, input_file):
     folder_name = mkdtemp()
     setting_file = os.path.join(folder_name, ".rstuf.yml")
     test_settings = Dynaconf()
-    test_settings.SERVER = "http://repository-service-tuf-api"
+    test_settings.SERVER = "http://repository-service-tuf-api:8080"
     test_settings.HEADERS = None
     context = {"settings": test_settings, "config": setting_file}
 

--- a/tests/functional/scripts/rstuf-admin-metadata-update.py
+++ b/tests/functional/scripts/rstuf-admin-metadata-update.py
@@ -12,7 +12,7 @@ def _run(input, selection, input_file):
     folder_name = mkdtemp()
     setting_file = os.path.join(folder_name, "rstuf.yml")
     test_settings = Dynaconf()
-    test_settings.SERVER = "http://repository-service-tuf-api"
+    test_settings.SERVER = "http://repository-service-tuf-api:8080"
     test_settings.HEADERS = None
     context = {"settings": test_settings, "config": setting_file}
 


### PR DESCRIPTION
[This change updates the umbrella repository to align with the non-root security hardening changes.

Changes:

* Updated docker-compose to run services as UID 1000
* Added no-new-privileges security option
* Updated documentation to reflect port changes (8080/8443)
* Updated deployment documentation for non-root containers

This PR coordinates the integration changes required for the non-root execution model across the full RSTUF stack.

Fixes #859
Related to #852
RSTUF-CR-25-111
](security: run services as non-root user (RSTUF-CR-25-111))

<!-- readthedocs-preview repository-service-tuf start -->
----
📚 Documentation preview 📚: https://repository-service-tuf--950.org.readthedocs.build/en/950/

<!-- readthedocs-preview repository-service-tuf end -->