### PR TITLE
docs: Add Getting Help page to guide with Slack channel info

### DIFF
--- a/docs/source/guide/general/getting-help.rst
+++ b/docs/source/guide/general/getting-help.rst
@@ -1,0 +1,53 @@
+############
+Getting Help
+############
+
+If you need help with Repository Service for TUF (RSTUF), there are several ways to reach out to the community:
+
+Slack Channel
+=============
+
+Join the RSTUF community on Slack to ask questions, share ideas, and get help from other users and maintainers.
+
+* Channel: `#repository-service-for-tuf <https://openssf.slack.com/archives/C052QF5CZFH>`_
+* Workspace: `OpenSSF Slack <https://openssf.slack.com/>`_
+
+The Slack channel is the best place for:
+
+* Quick questions and answers
+* Real-time discussions
+* Community support
+* Sharing experiences and best practices
+
+Community Meetings
+==================
+
+Join our monthly community meetings to discuss RSTUF development, share feedback, and connect with other users.
+
+* **Time**: First Wednesday of the month at 15:00 UTC/11:00am EST/4:00pm PST
+* **Location**: `Zoom link <https://zoom-lfx.platform.linuxfoundation.org/meeting/93810832920?password=b3f09489-f959-40d1-89b7-12f10d2ad2cb>`_
+* **Agenda and notes**: https://hackmd.io/jdAk9rmPSpOYUdstbIvbjw
+* **Calendar**: `Linux Foundation Calendar <https://zoom-lfx.platform.linuxfoundation.org/meetings/tuf?view=month>`_
+
+Mailing List
+============
+
+Subscribe to the RSTUF mailing list for announcements, discussions, and updates.
+
+* **Subscribe**: https://lists.openssf.org/g/RSTUF
+* **Email**: RSTUF@lists.openssf.org
+
+GitHub Issues
+=============
+
+For bug reports, feature requests, and technical issues, please use GitHub Issues:
+
+* `Repository Service for TUF (Umbrella) <https://github.com/repository-service-tuf/repository-service-tuf/issues>`_
+* `RSTUF API <https://github.com/repository-service-tuf/repository-service-tuf-api/issues>`_
+* `RSTUF Worker <https://github.com/repository-service-tuf/repository-service-tuf-worker/issues>`_
+* `RSTUF CLI <https://github.com/repository-service-tuf/repository-service-tuf-cli/issues>`_
+
+Contributing
+============
+
+Interested in contributing to RSTUF? Check out our :doc:`/devel/contributing` guide to learn how to get started.

--- a/docs/source/guide/index.rst
+++ b/docs/source/guide/index.rst
@@ -11,6 +11,7 @@ Repository Service for TUF Guide
     general/keys
     deployment/index
     general/client
+    general/getting-help
 
 Components documentation
 ########################


### PR DESCRIPTION
Fixes #406

Added a new 'Getting Help' page to the guide that includes:
- Slack channel information (#repository-service-for-tuf on OpenSSF Slack)
- Community meetings details
- Mailing list information
- GitHub Issues links
- Link to contributing guide

This makes it easier for users to find help and connect with the RSTUF community.

<!-- readthedocs-preview repository-service-tuf start -->
----
Documentation preview : https://repository-service-tuf--956.org.readthedocs.build/en/956/

<!-- readthedocs-preview repository-service-tuf end -->