### PR TITLE
docs: clarify artifact hash digest format as hexadecimal

### DIFF
--- a/docs/source/guide/general/usage.rst
+++ b/docs/source/guide/general/usage.rst
@@ -114,7 +114,7 @@ Add artifacts payload
       - `A hash algorithm names <https://theupdateframework.github.io/specification/latest/#targets-obj-length>`_
       - ``sha256``
     * - ``HASH``
-      - The hash output, such as ``shasum -a 256 <artifact>``
+      - The `hexadecimal digest <https://theupdateframework.github.io/specification/latest/#targets-obj-hashes>`_ of the artifact hash, such as ``shasum -a 256 <artifact>``
       - ``95cef21e0d8707e4b46c85cd130a37c5c03f747f140b7d9e2bd817b7fcc13511``
     * - ``CUSTOM``
       - Custom key-value pairs

--- a/docs/source/guide/repository-service-tuf-cli/index.rst
+++ b/docs/source/guide/repository-service-tuf-cli/index.rst
@@ -316,7 +316,7 @@ This content requires the following data:
 - `path <https://theupdateframework.github.io/specification/latest/#targetpath>`_: The artifact path
 - `size <https://theupdateframework.github.io/specification/latest/#targets-obj-length>`_: The artifact size
 - `hash-type <https://theupdateframework.github.io/specification/latest/#targets-obj-length>`_: The defined hash as a metafile. Example: blak2b-256
-- `hash <https://theupdateframework.github.io/specification/latest/#targets-obj-length>`_: The hash
+- `hash <https://theupdateframework.github.io/specification/latest/#targets-obj-hashes>`_: The `hexadecimal digest <https://theupdateframework.github.io/specification/latest/#targets-obj-hashes>`_ of the artifact hash
 
 The CSV must use a semicolon as the separator, following the format
 ``path;size;hash-type;hash`` without a header.


### PR DESCRIPTION
- Updated usage.rst to specify hash as hexadecimal digest with TUF spec reference
- Updated CLI index.rst to clarify hash format with proper TUF spec link
- Added references to TUF specification targets HASHES section for both docs
- Links now point to targets-obj-hashes anchor for target file hashes

Fixes #523

<!-- readthedocs-preview repository-service-tuf start -->
----
Documentation preview : https://repository-service-tuf--957.org.readthedocs.build/en/957/

<!-- readthedocs-preview repository-service-tuf end -->