### PR TITLE
feat: integrate TUF metadata visualizer into RSTUF docker setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     volumes:
       - repository-service-tuf-api-data:/data
     ports:
-      - 80:80
+      - 8000:80
     environment:
       - RSTUF_BROKER_SERVER=redis://redis
       - RSTUF_REDIS_SERVER=redis://redis
@@ -75,3 +75,16 @@ services:
     working_dir: /rstuf-runner
     volumes:
       - ./:/rstuf-runner
+
+  rstuf-visualizer:
+    build:
+      context: ../TUF-Metadata-Visualizer
+      dockerfile: Dockerfile
+      args:
+        - NEXT_PUBLIC_RSTUF_API=http://repository-service-tuf-api:80/api/v1/metadata/
+    ports:
+      - "3000:3000"
+    environment:
+      - NEXT_PUBLIC_RSTUF_API=http://repository-service-tuf-api:80/api/v1/metadata/
+    depends_on:
+      - repository-service-tuf-api


### PR DESCRIPTION
This PR integrates the TUF Metadata Visualizer into the RSTUF docker-based deployment.

Changes:

* Added a `rstuf-visualizer` service using local build context.
* Configured `NEXT_PUBLIC_RSTUF_API` to point to `http://repository-service-tuf-api:80/api/v1/metadata/`.
* Updated API port mapping from `80:80` to `8000:80` to avoid conflicts.

Result:
The visualizer can run alongside the RSTUF stack and display metadata after repository bootstrap.

Validation:

* `docker-compose up` completes successfully
* API available at `http://localhost:8000`
* Visualizer available at `http://localhost:3000`
* Metadata loads correctly in the UI

Related work:

* Helm integration: https://github.com/repository-service-tuf/helm-charts/pull/58
* Visualizer updates: https://github.com/DeshDeepakKant/TUF-Metadata-Visualizer/pull/38

These PRs together complete the end-to-end integration of the TUF Metadata Visualizer with RSTUF.

