### PR TITLE
ci: add automated security baseline checks with SARIF reporting (#932)

### DIFF
--- a/.github/workflows/osps-baseline.yml
+++ b/.github/workflows/osps-baseline.yml
@@ -1,0 +1,28 @@
+name: Security Baseline Checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  osps-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+
+      - name: Upload SARIF results
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/SECURITY_INSIGHTS.yml
+++ b/SECURITY_INSIGHTS.yml
@@ -45,3 +45,6 @@ security-artifacts:
       comment: |
         Security assessment conducted by X41 D-Sec GmbH. The assessment focused on the design,
         implementation, and deployment of RSTUF services and tools.
+
+security-tooling:
+  automated-security-scanning: true


### PR DESCRIPTION
This PR introduces automated security baseline checks for the RSTUF project as part of the OSPS Mechanizer objective.

Changes:

Added a GitHub Actions workflow to run security baseline checks on pull requests and main branch updates
Integrated SARIF upload to surface results in the repository Security tab
Updated SECURITY_INSIGHTS.yml to reflect automated security scanning

Scope:

Focused on CI-based security automation
No changes to application code or runtime behavior

Closes #932