### PR TITLE
docs: add OpenSSF Best Practices badge for Defender objective (#933)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,12 +3,12 @@ Repository Service for TUF (RSTUF)
 
 .. image:: ./docs/source/_static/logo/PNG/rstuf_horizontal-color.png
 
-.. readme-logo
-
 |OpenSSF Best Practices|
 
 .. |OpenSSF Best Practices| image:: https://bestpractices.coreinfrastructure.org/projects/6587/badge
   :target: https://bestpractices.coreinfrastructure.org/projects/6587
+
+.. readme-logo
 
 .. readme-intro
 

--- a/SECURITY_INSIGHTS.yml
+++ b/SECURITY_INSIGHTS.yml
@@ -39,6 +39,7 @@ documentation:
   project-members: https://github.com/repository-service-tuf/repository-service-tuf/blob/main/MAINTAINERS.rst
 
 security-artifacts:
+  best-practices-badge: https://bestpractices.coreinfrastructure.org/projects/6587
   third-party-assessments:
     - evidence: https://repository-service-tuf.readthedocs.io/en/stable/blog/posts/rstuf-security-audit-for-1.0.0.html
       date: "2025-02-14"


### PR DESCRIPTION
This PR completes the Defender objective of the OpenSSF Security Slam by integrating the OpenSSF Best Practices badge into the RSTUF project.

Changes:

* Added OpenSSF Best Practices badge to README.rst using correct reStructuredText format
* Updated SECURITY_INSIGHTS.yml to include the best-practices-badge reference

Scope:

* Limited to documentation updates only
* No changes to application code or infrastructure

Context:
This builds on previous Security Slam objectives (Cleaner, Chronicler, Inspector, Mechanizer) and reflects the project's overall security maturity and alignment with OSPS Baseline practices.

Closes #933


<!-- readthedocs-preview repository-service-tuf start -->
----
📚 Documentation preview 📚: https://repository-service-tuf--965.org.readthedocs.build/en/965/

<!-- readthedocs-preview repository-service-tuf end -->