### PR TITLE
docs: add update mechanism guidance for deployment security (#858)

### DIFF
--- a/docs/source/guide/deployment/index.rst
+++ b/docs/source/guide/deployment/index.rst
@@ -38,3 +38,41 @@ Deployment Planning
    planning/services
    planning/networking
 
+
+Security Updates and Maintenance
+-------------------------------
+
+Deployments should be kept up to date to apply security patches.
+
+The RSTUF deployment includes multiple components that require regular updates:
+* API (Repository Service for TUF API)
+* Worker (Repository Service for TUF Worker)
+* Redis (message queue and result backend)
+* PostgreSQL (metadata storage)
+
+Update Strategy
+===============
+
+Regularly pull updated Docker images and restart services to apply changes.
+
+Example update workflow:
+
+.. code-block:: shell
+
+   docker compose pull
+   docker compose up -d
+
+Security Communication
+======================
+
+Security updates are communicated through:
+* GitHub Releases
+* GitHub Security Advisories
+
+Operational Responsibility
+==========================
+
+Administrators should monitor for updates and apply patches in a timely manner.
+
+Updates should be tested before being applied to production systems.
+


### PR DESCRIPTION
This PR addresses the security audit finding RSTUF-CR-25-110 (Issue #858) by adding guidance on the update mechanism for RSTUF deployments.

The added section defines the maintenance process, including the update strategy for core services (API, Worker, Redis, PostgreSQL), communication channels for security patches, and operational responsibilities for administrators. 

The scope of this PR is strictly documentation.

Closes #858


<!-- readthedocs-preview repository-service-tuf start -->
----
📚 Documentation preview 📚: https://repository-service-tuf--966.org.readthedocs.build/en/966/

<!-- readthedocs-preview repository-service-tuf end -->