### PR TITLE
security: improve docker container security (#854)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,11 @@ services:
 
   repository-service-tuf-api:
     image: ghcr.io/repository-service-tuf/repository-service-tuf-api:${API_VERSION}
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
     volumes:
       - repository-service-tuf-api-data:/data
     ports:
@@ -51,6 +56,11 @@ services:
 
   repository-service-tuf-worker:
     image: ghcr.io/repository-service-tuf/repository-service-tuf-worker:${WORKER_VERSION}
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
     environment:
       - RSTUF_STORAGE_BACKEND=LocalStorage
       - RSTUF_LOCAL_STORAGE_BACKEND_PATH=/var/opt/repository-service-tuf/storage


### PR DESCRIPTION
## What was the issue

The Docker setup did not include basic security protections. Containers were running with full write access and without restricting privilege escalation, which is not safe.

## What was changed

- Added `read_only: true` for API and Worker containers  
- Added `no-new-privileges:true` to prevent privilege escalation  
- Added `tmpfs: /tmp` to allow temporary files without breaking runtime  

## Testing

- Ran the setup using `docker compose up --build`
- Checked running containers with `docker ps`
- Verified logs to make sure there are no errors
- Confirmed API and Worker are running properly

## Notes

This change only improves container security. No functional changes were made.

Closes #854