### PR TITLE
docs: update deployment docs and remove outdated usage (#855)

### DIFF
--- a/docs/source/guide/deployment/guide/docker-compose.yml
+++ b/docs/source/guide/deployment/guide/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       RSTUF_ONLINE_KEY_DIR: /var/opt/repository-service-tuf/keyvault
       RSTUF_BROKER_SERVER: redis://redis
       RSTUF_REDIS_SERVER: redis://redis
-      RSTUF_SQL_SERVER: postgresql://postgres:secret@postgres:5432
+      RSTUF_DB_SERVER: postgresql://postgres:secret@postgres:5432
 
     depends_on:
       - postgres

--- a/docs/source/guide/deployment/guide/docker.rst
+++ b/docs/source/guide/deployment/guide/docker.rst
@@ -80,7 +80,7 @@ Steps
      - Online Key directory: ``RSTUF_ONLINE_KEY_DIR``
      - Broker Server: ``RSTUF_BROKER_SERVER``
      - Redis Server: ``RSTUF_REDIS_SERVER``
-     - SQL (Postgres) Server: ``RSTUF_SQL_SERVER``
+     - SQL (Postgres) Server: ``RSTUF_DB_SERVER``
 
 3. Run using Docker stack
 

--- a/docs/source/guide/deployment/guide/k8s/deployment.yml
+++ b/docs/source/guide/deployment/guide/k8s/deployment.yml
@@ -150,11 +150,11 @@ spec:
               value: redis://redis
             - name: RSTUF_REDIS_SERVER
               value: redis://redis
-            - name: RSTUF_SQL_SERVER
-              value: postgres:5433
-            - name: RSTUF_SQL_USER
-              value: postgres
-            - name: RSTUF_SQL_PASSWORD
+            - name: RSTUF_DB_SERVER
+              value: "postgres:5433"
+            - name: RSTUF_DB_USER
+              value: "postgres"
+            - name: RSTUF_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: postgrespassword

--- a/docs/source/guide/deployment/guide/kubernetes.rst
+++ b/docs/source/guide/deployment/guide/kubernetes.rst
@@ -250,10 +250,10 @@ rstuf-worker deployment
   - environment variables ``RSTUF_BROKER_SERVER`` and ``RSTUF_REDIS_SERVER`` as
     :ref:`guide/deployment/guide/kubernetes:redis deployment` (``redis://redis``).
 
-  - environment variables ``RSTUF_SQL_SERVER`` as
+  - environment variables ``RSTUF_DB_SERVER`` as
     the :ref:`guide/deployment/guide/kubernetes:postgres deployment`
-    (``postgres:5432``), ``RSTUF_SQL_USER`` as ``postgres``, and
-    ``RSTUF_SQL_PASSWORD`` as the :ref:`guide/deployment/guide/kubernetes:postgrespassword secret`.
+    (``postgres:5432``), ``RSTUF_DB_USER`` as ``postgres``, and
+    ``RSTUF_DB_PASSWORD`` as the :ref:`guide/deployment/guide/kubernetes:postgrespassword secret`.
 
   - environment variable ``RSTUF_ONLINE_KEY_DIR`` as
     :ref:`guide/deployment/guide/kubernetes:onlinekey secret`

--- a/docs/source/guide/deployment/setup.rst
+++ b/docs/source/guide/deployment/setup.rst
@@ -156,8 +156,7 @@ as the RSTUF service is ready.
 
 To perform the boostrap you require the payload generated during the
 :ref:`guide/deployment/setup:Bootstrap`.
-
-You can do it using the rstuf admin-legacy
+You can do it using the rstuf admin:
 
 .. code::
 


### PR DESCRIPTION
## What was the issue

Some parts of the documentation were outdated and not matching the current implementation.  
This included usage of old CLI commands and deprecated environment variable names.

## What was changed

- Replaced `rstuf admin-legacy` with `rstuf admin`
- Updated environment variables from `RSTUF_SQL_*` to `RSTUF_DB_*`
- Fixed references across Docker, Kubernetes, and setup documentation

## Testing

- Reviewed all updated files to ensure consistency
- Verified that no old references remain in the modified sections

## Notes

This PR only updates documentation and does not affect runtime behavior.

Closes #855

<!-- readthedocs-preview repository-service-tuf start -->
----
📚 Documentation preview 📚: https://repository-service-tuf--968.org.readthedocs.build/en/968/

<!-- readthedocs-preview repository-service-tuf end -->